### PR TITLE
add functionality for retrying failed HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,42 @@ options.withUploadFiles([
                 <code>options.withAddContentLengthHeader(true);</code>
             </td>
         </tr>
+        <tr>
+            <td>http retry count</td>
+            <td>number</td>
+            <td>
+                The number of times that the process will retry a failed HTTP request before
+                giving up. For example, if the retry count is 3 then the process will submit
+                the same HTTP request up to 3 times if the response indicates a failure.
+                <br/>
+                <br/>
+                Default: <code>3</code>
+                <br/>
+                <br/>
+                <b>Example</b>
+                <br/>
+                <code>options.withHttpRetryCount(5);</code>
+            </td>
+        </tr>
+        <tr>
+            <td>http retry delay</td>
+            <td>number</td>
+            <td>
+                The amount of time that the process will wait before retrying a failed HTTP
+                request. The value is specified in milliseconds. With each increasing retry,
+                the delay will increase by its value. For example, if the delay is 5000 then
+                the first retry will wait 5 seconds, the second 10 seconds, the third 15
+                seconds, etc.
+                <br/>
+                <br/>
+                Default: <code>5000</code>
+                <br/>
+                <br/>
+                <b>Example</b>
+                <br/>
+                <code>options.withHttpRetryDelay(3000);</code>
+            </td>
+        </tr>
     </tbody>
 </table>
 
@@ -388,6 +424,13 @@ upload.uploadFiles(options) // assume that options is defined previously
 
 Another way of handling individual file errors is to listen for the upload process's
 [Events](#upload-events).
+
+The process implements automatic HTTP retry handling, meaning that if an HTTP request fails
+then the process will wait for a specified interval and retry the same HTTP request a given
+number of times. If the request still fails after the given number of retries, it will
+report the error as normal using the last error. Any errors that caused a retry, in
+either a success scenario or failure scenario, will be reported in the result in a dedicated
+structure.
 
 ### Upload Events
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,4 +18,17 @@ export const DefaultValues = {
      * The default number of maximum concurrent HTTP requests allowed by the library.
      */
     MAX_CONCURRENT: 5,
+
+    /**
+     * The default number of times the process will attempt submitting an HTTP request
+     * before giving up and reporting a failure.
+     */
+    RETRY_COUNT: 3,
+
+    /**
+     * The amount of time, in milliseconds, that the process will wait between retries
+     * of the same HTTP request. The delay will increase itself by this value for
+     * each retry.
+     */
+    RETRY_DELAY: 5000,
 }

--- a/src/direct-binary-upload-options.js
+++ b/src/direct-binary-upload-options.js
@@ -32,6 +32,8 @@ export default class DirectBinaryUploadOptions {
         this.options = {
             maxConcurrent: DefaultValues.MAX_CONCURRENT,
             headers: {},
+            retryCount: DefaultValues.RETRY_COUNT,
+            retryDelay: DefaultValues.RETRY_DELAY,
         };
         this.controller = new DirectBinaryUploadController();
     }
@@ -145,6 +147,30 @@ export default class DirectBinaryUploadOptions {
     }
 
     /**
+     * Specifies the number of times the process will attempt retrying a failed HTTP request before
+     * giving up and reporting an error. Default: 3.
+     *
+     * @param {number} retryCount Number of times to resubmit a request.
+     */
+    withHttpRetryCount(retryCount) {
+        this.options.retryCount = retryCount;
+        return this;
+    }
+
+    /**
+     * Sets the amount of time, in milliseconds, that the process will wait before retrying a
+     * failed HTTP request. The delay will increase itself by this value each time the failed
+     * request is resubmitted. For example, if the delay is 5,000 then the process will wait
+     * 5,000 milliseconds for the first retry, then 10,000, then 15,000, etc. Default: 5,000.
+     *
+     * @param {number} retryDelay A timespan in milliseconds.
+     */
+    withHttpRetryDelay(retryDelay) {
+        this.options.retryDelay = retryDelay;
+        return this;
+    }
+
+    /**
      * Retrieves the target URL to which files will be uploaded.
      *
      * @returns {string} Target URL as provided to the options instance.
@@ -234,6 +260,25 @@ export default class DirectBinaryUploadOptions {
      */
     getController() {
         return this.controller;
+    }
+
+    /**
+     * Retrieves the number of times the process will attempt to resubmit a failed HTTP request.
+     *
+     * @returns {number} Retry count.
+     */
+    getHttpRetryCount() {
+        return this.options.retryCount;
+    }
+
+    /**
+     * Retrieves the amount of time, in milliseconds, the process wil wait between resubmitting
+     * the same failed HTTP request.
+     *
+     * @returns {number} Timespan in milliseconds.
+     */
+    getHttpRetryDelay() {
+        return this.options.retryDelay;
     }
 
     /**

--- a/src/error-codes.js
+++ b/src/error-codes.js
@@ -54,4 +54,9 @@ export default {
      * The user is forbidden from modifying the requested target.
      */
     FORBIDDEN: 'EFORBIDDEN',
+
+    /**
+     * The user cancelled an operation.
+     */
+    USER_CANCELLED: 'EUSERCANCELLED',
 };

--- a/src/file-upload-result.js
+++ b/src/file-upload-result.js
@@ -14,19 +14,24 @@ import filesize from 'filesize';
 
 import { getAverage } from './utils';
 import UploadError from './upload-error';
+import HttpResult from './http-result';
 
 /**
  * Represents the results of an individual file upload. These results include information like
  * the amount of time the file took to upload, the number of parts in which the file was uploaded,
  * and any error information that may have occurred during the upload.
  */
-export default class FileUploadResult {
+export default class FileUploadResult extends HttpResult {
     /**
      * Constructs a new instance of the result, which can be used to provide result values.
      *
+     * @param {object} options Options as provided when the upload instance was instantiated.
+     * @param {DirectBinaryUploadOptions} uploadOptions Options as provided when the upload was initiated.
      * @param {InitResponseFile} initResponseFile File information on which the results are based.
      */
-    constructor(initResponseFile) {
+    constructor(options, uploadOptions, initResponseFile) {
+        super(options, uploadOptions);
+
         this.initResponseFile = initResponseFile;
         this.parts = [];
         this.cancelled = false;
@@ -239,6 +244,7 @@ export default class FileUploadResult {
             success: this.isSuccessful(),
             message,
             partDetails: this.parts.map(part => part.toJSON()),
+            ...super.toJSON(),
         };
 
         if (this.isCancelled()) {

--- a/src/http-result.js
+++ b/src/http-result.js
@@ -1,0 +1,63 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import UploadOptionsBase from './upload-options-base';
+import UploadError from './upload-error';
+
+export default class HttpResult extends UploadOptionsBase {
+    /**
+     * Constructs a new instance of the results, which can be used to add more information.
+     */
+    constructor(options, uploadOptions) {
+        super(options, uploadOptions);
+
+        this.retryErrors = [];
+    }
+
+    /**
+     * Adds an error to the result's list of retry errors.
+     *
+     * @param {Error|string} e An error that occurred.
+     */
+    addRetryError(e) {
+        this.retryErrors.push(UploadError.fromError(e));
+    }
+
+    /**
+     * Retrieves the list of retry errors that occurred within the result's scope.
+     *
+     * @returns {Array} List of UploadError instances.
+     */
+    getRetryErrors() {
+        return this.retryErrors;
+    }
+
+    /**
+     * Converts the result to its JSON string representation.
+     *
+     * @returns {string} The result as a string.
+     */
+    toString() {
+        return JSON.stringify(this.toJSON());
+    }
+
+    /**
+     * Converts the result to a simple object.
+     *
+     * @returns {object} Result information.
+     */
+    toJSON() {
+        return {
+            retryErrors: this.retryErrors,
+        };
+    }
+}

--- a/src/http-utils.js
+++ b/src/http-utils.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import axios, { CancelToken } from 'axios';
 
 import UploadError from './upload-error';
+import { exponentialRetry } from './utils';
 
 /**
  * Retrieves a token that can be used to cancel an http request.
@@ -25,24 +26,40 @@ export function createCancelToken() {
 
 /**
  * Submits an HTTP requests and provides the amount of time it took (in milliseconds) for the request to complete.
+ * In addition, the method will retry the request according to the provided retry options.
  *
  * @param {object} requestOptions Will be passed as-is to the underlying HTTP request processor, axios.
+ * @param {object} retryOptions Determines the behavior of the retry functionality.
+ * @param {number} [retryOptions.retryCount] Specifies how many times, in total, the request will be submitted before giving up.
+ * @param {number} [retryOptions.retryDelay] Specifies the amount of time to wait before retrying. The actual wait time will
+ *   exponentially increase by this value for each retry.
+ * @param {function} [retryOptions.onRetryError] Will be invoked with a single error before each retry. If all retries fail, the
+ *   method will resolved with the last error instead. If this function throws an exception then the retry functionality
+ *   will immediately be resolved with the thrown exception.
  * @param {Object} [cancelToken] If specified, can be used to cancel the request.
  * @returns {object} The response to the request, which will match the signature of an axios response. In addition
  *  to typical axios response data, the object will also have an "elapsedTime" property containing the amount
  *  of time (in milliseconds) it took for the request to complete.
  */
-export async function timedRequest(requestOptions, cancelToken) {
+export async function timedRequest(requestOptions, retryOptions, cancelToken) {
     const reqStart = new Date().getTime();
     const options = { ...requestOptions };
+
+    if (options.onRetryError) {
+        delete options.onRetryError;
+    }
 
     if (cancelToken) {
         options.cancelToken = cancelToken.token;
     }
 
+    let response;
+
     try {
-        const response = await axios(options);
-        response.elapsedTime = new Date().getTime() - reqStart;
+        await exponentialRetry(retryOptions, async () => {
+            response = await axios(options);
+            response.elapsedTime = new Date().getTime() - reqStart;
+        });
         return response;
     } catch (e) {
         throw UploadError.fromError(e);

--- a/src/part-upload-result.js
+++ b/src/part-upload-result.js
@@ -12,21 +12,26 @@ governing permissions and limitations under the License.
 
 import UploadError from './upload-error';
 
+import HttpResult from './upload-result';
+
 /**
  * Represents the results of an individual file part upload. These results contain information such as
  * the amount of time it took to transfer, and any error that may have occurred.
  */
-export default class PartUploadResult {
+export default class PartUploadResult extends HttpResult {
     /**
      * Constructs a new instance using the provided information. Can then be used to provide additional details
      * as needed.
      *
+     * @param {object} options Options as provided when the upload instance was instantiated.
+     * @param {DirectBinaryUploadOptions} uploadOptions Options as provided when the upload was initiated.
      * @param {InitResponseFilePart} filePart The part on which the results are based.
-     * @param {number} elapsedTime The amount of time, in milliseconds, it took the part to upload.
      */
-    constructor(filePart, elapsedTime) {
+    constructor(options, uploadOptions, filePart) {
+        super(options, uploadOptions);
+
         this.filePart = filePart;
-        this.elapsedTime = elapsedTime;
+        this.elapsedTime = 0;
     }
 
     /**
@@ -63,6 +68,15 @@ export default class PartUploadResult {
      */
     getUploadTime() {
         return this.elapsedTime;
+    }
+
+    /**
+     * Sets the amount of time, in milliseconds, it took for the part to upload.
+     *
+     * @param {number} elapsedTime Time span in milliseconds.
+     */
+    setUploadTime(elapsedTime) {
+        this.elapsedTime = elapsedTime;
     }
 
     /**
@@ -104,6 +118,7 @@ export default class PartUploadResult {
             url: this.getUrl(),
             message: this.getError() ? this.getError().getMessage() : '',
             elapsedTime: this.getUploadTime(),
+            ...super.toJSON(),
         };
     }
 }

--- a/src/upload-result.js
+++ b/src/upload-result.js
@@ -11,7 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import { getAverage } from './utils';
-import UploadOptionsBase from './upload-options-base';
+import HttpResult from './http-result';
 
 /**
  * Retrieves a list of all file results that were successful.
@@ -33,7 +33,7 @@ function getSuccessfulFileResults(fileResults) {
  * Represents results for the upload process as a whole, which might include multiple files. Results
  * include information such as total upload time, total file size, total number of files, etc.
  */
-export default class UploadResult extends UploadOptionsBase {
+export default class UploadResult extends HttpResult {
     /**
      * Constructs a new instance of the results, which can be used to add more information.
      *
@@ -246,6 +246,7 @@ export default class UploadResult extends UploadOptionsBase {
             avgCompleteSpent: this.getAverageCompleteTime(),
             nintyPercentileTotal: this.getNinetyPercentileTotal(),
             detailedResult: this.fileUploadResults.map(result => result.toJSON()),
+            ...super.toJSON(),
         };
     }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -88,3 +88,64 @@ export function getAverage(values) {
     }
     return 0;
 }
+
+/**
+ * Utility method that provides a Promise interface for setTimeout().
+ *
+ * @param {number} delay The amount of time, in milliseconds, to wait before the method resolves.
+ * @returns {Promise} Will be resolved when the specified delay has elapsed.
+ */
+export function setTimeoutPromise(delay) {
+    return new Promise(res => {
+        setTimeout(res, delay);
+    });
+}
+
+/**
+ * Retries an operation a given number of times, exponentially increasing the amount of time between each retry by a
+ * specified interval.
+ *
+ * @param {object} retryOptions Determines the behavior of the retry functionality.
+ * @param {number} [retryOptions.retryCount] Specifies how many times, in total, the operation will be retried before giving up.
+ * @param {number} [retryOptions.retryDelay] Specifies the amount of time to wait before retrying. The actual wait time will
+ *   exponentially increase by this value with each retry.
+ * @param {function} [retryOptions.onRetryError] Will be invoked with a single error before each retry. If all retries fail, the
+ *   method will resolved with the last error instead. If this function throws an exception then the retry functionality
+ *   will immediately be resolved with the thrown exception.
+ * @param {function} toRetry The operation to retry. The function is expected to return a Promise, which is resolved if
+ *   the operation is successful and rejected with an error if the operation fails.
+ * @returns {Promise} Will be resolved successfully if no exception is thrown by the operation withing the specified
+ *   number of tries. Will be rejected with the last error if all retries fail.
+ */
+export async function exponentialRetry(options, toRetry) {
+    if (typeof options === 'function') {
+        toRetry = options;
+        options = {};
+    }
+
+    const {
+        retryCount = DefaultValues.RETRY_COUNT,
+        retryDelay = DefaultValues.RETRY_DELAY,
+        onRetryError = () => {},
+    } = options;
+
+    let lastErr = null;
+
+    for (let i = 1; i <= retryCount; i += 1) {
+        try {
+            await toRetry();
+            lastErr = null;
+            break;
+        } catch (e) {
+            lastErr = e;
+            if (i < retryCount) {
+                onRetryError(e);
+                await setTimeoutPromise(retryDelay * i);
+            }
+        }
+    }
+
+    if (lastErr) {
+        throw lastErr;
+    }
+}

--- a/test/http-utils.test.js
+++ b/test/http-utils.test.js
@@ -37,7 +37,7 @@ describe('HttpUtilsTest', () => {
                 elapsedTime,
             } = await timedRequest({
                 url: 'http://timedrequestunittest',
-            });
+            }, {});
 
             should(status).be.exactly(200);
             should(elapsedTime >= 100).be.ok();

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -14,7 +14,7 @@ const should = require('should');
 
 const { importFile } = require('./testutils');
 
-const { concurrentLoop } = importFile('utils');
+const { concurrentLoop, exponentialRetry } = importFile('utils');
 const { DefaultValues } = importFile('constants');
 
 describe('UtilsTest', () => {
@@ -54,5 +54,47 @@ describe('UtilsTest', () => {
         it('test max concurrent value', async () => {
             await runMaxConcurrentTest(7);
         });
+    });
+
+    it('test exponential retry', async () => {
+        const start = new Date().getTime();
+        let count = 0;
+        let verified = false;
+
+        try {
+            await exponentialRetry({
+                retryCount: 4,
+                retryDelay: 100,
+            }, async () => {
+                count++;
+                const currTime = new Date().getTime();
+
+                if (count === 1) {
+                    should(currTime - start).be.lessThan(100);
+                } else if (count === 2) {
+                    should(currTime - start).be.greaterThanOrEqual(100);
+                    should(currTime - start).be.lessThan(200);
+                } else if (count === 3) {
+                    should(currTime - start).be.greaterThanOrEqual(300);
+                    should(currTime - start).be.lessThan(400);
+                } else if (count === 4) {
+                    should(currTime - start).be.greaterThanOrEqual(600);
+                    should(currTime - start).be.lessThan(700);
+                } else {
+                    // should not happen this many times
+                    should(false).be.ok();
+                }
+
+                throw `gonna fail ${count}`;
+            });
+        } catch (e) {
+            verified = true;
+            const currTime = new Date().getTime();
+            should(currTime - start).be.greaterThanOrEqual(600);
+            should(currTime - start).be.lessThan(700);
+            should(e).be.exactly('gonna fail 4');
+            should(count).be.exactly(4);
+        }
+        should(verified).be.ok();
     });
 });


### PR DESCRIPTION
## Description

I've updated the library so that it implements a "backoff" retry strategy when it comes to failed HTTP requests.

If a request fails, the process will delay for a specified amount of time before resubmitting the request a specified number of times. Both values are configurable, but the default retry count is 3 with a delay of 5 seconds. Each time the process retries the request, it will increase the delay.

As an example, an error scenario with the default values might look like this:

* Submit HTTP request, which fails with an error code.
* Wait 5 seconds.
* Submit HTTP request, which again fails with an error code.
* Wait 10 seconds.
* Submit HTTP request, which again fails with an error code.
* Process discontinues and reports the last error. If the retry count were higher, then the delay would increase to 15 seconds, then 20 seconds, then 25 seconds, etc.

A success scenario with the default values might look like this:

* Submit HTTP request, which fails with an error code.
* Wait 5 seconds.
* Submit HTTP request, which succeeds.
* Process continues.

In an error scenario, only the last error is reported. In both success and error scenarios, any failures that are _not_ the last error will be reported in the results as a new "retry error."

The primary change is the addition of a new utility function called [exponentialRetry()](https://github.com/adobe/aem-upload/commit/543fd89eebcbbefc13056b110d74fd1f24937ac2#diff-2b4ca49d4bb0a774c4d4c1672d7aa781R120). The function accepts another function, which it will invoke using the retry functionality described. It receives options that control the number of times to retry, the retry delay, and an optional callback that will be invoked each time there is a retry error.

The majority of the remaining changes are related to reporting errors that cause a retry but don't fail the entire process. They are reported as a new item in the results. Additional code is for the new unit tests.

## Related Issue

[Issue #1](https://github.com/adobe/aem-upload/issues/1)

## Motivation and Context

HTTP can be unreliable at times. By automatically retrying failed HTTP requests, the library can have some handling of (for example) intermittent network issues.

## How Has This Been Tested?

Added unit tests for the new method that handles retrying a function. Also added unit tests for covering the success scenario described above for the "initiate," "part," and "complete" HTTP requests. Also verified that existing unit tests continue to pass.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
