### PR TITLE
correctly handle upload URLs that have a trailing forward slash.

### DIFF
--- a/src/direct-binary-upload-options.js
+++ b/src/direct-binary-upload-options.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import URL from 'url';
 
 import DirectBinaryUploadController from './direct-binary-upload-controller';
+import { trimRight } from './utils';
 import { DefaultValues } from './constants';
 
 /**
@@ -176,7 +177,7 @@ export default class DirectBinaryUploadOptions {
      * @returns {string} Target URL as provided to the options instance.
      */
     getUrl() {
-        return this.options.url;
+        return trimRight(this.options.url, ['/']) || '/';
     }
 
     /**

--- a/src/utils.js
+++ b/src/utils.js
@@ -149,3 +149,64 @@ export async function exponentialRetry(options, toRetry) {
         throw lastErr;
     }
 }
+
+function buildCharRegex(charArray) {
+    let regex = '[';
+
+    charArray.forEach(char => {
+        if (char === '\\' || char === ']') {
+            regex += '\\';
+        }
+        regex += char;
+    });
+
+    regex += ']';
+
+    return regex;
+}
+
+/**
+ * Removes a given set of characters from the end of a string.
+ *
+ * @param {string} toTrim The value to be trimmed.
+ * @param {Array} charArray An array of single characters to trim.
+ */
+export function trimRight(toTrim, charArray) {
+    if (toTrim && toTrim.replace) {
+        return toTrim.replace(new RegExp(`${buildCharRegex(charArray)}*$`, 'g'), '');
+    }
+    return toTrim;
+}
+
+/**
+ * Removes a given set of characters from the beginning of a string.
+ *
+ * @param {string} toTrim The value to be trimmed.
+ * @param {Array} charArray An array of single characters to trim.
+ */
+export function trimLeft(toTrim, charArray) {
+    if (toTrim && toTrim.replace) {
+        return toTrim.replace(new RegExp(`^${buildCharRegex(charArray)}*`, 'g'), '');
+    }
+    return toTrim;
+}
+
+/**
+ * Joins a list of values together to form a URL path. Each of the given values
+ * is guaranteed to be separated from all other values by a forward slash.
+ *
+ * @param  {...string} theArguments Any number of parameters to join.
+ */
+export function joinUrlPath(...theArguments) {
+    let path = '';
+
+    theArguments.forEach(arg => {
+        const toJoin = trimRight(trimLeft(arg, ['/']), ['/']);
+
+        if (toJoin) {
+            path += `/${toJoin}`;
+        }
+    });
+
+    return path;
+}

--- a/test/direct-binary-upload-options.test.js
+++ b/test/direct-binary-upload-options.test.js
@@ -1,0 +1,28 @@
+/*
+Copyright 2019 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const should = require('should');
+
+const { importFile } = require('./testutils');
+
+const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
+
+describe('DirectBinaryUploadOptionsTest', () => {
+    it('test url slashes', () => {
+        const options = new DirectBinaryUploadOptions()
+            .withUrl('/');
+
+        should(options.getUrl()).be.exactly('/');
+        options.withUrl('/trailing/');
+        should(options.getUrl()).be.exactly('/trailing');
+    });
+});

--- a/test/direct-binary-upload-process.test.js
+++ b/test/direct-binary-upload-process.test.js
@@ -178,5 +178,26 @@ describe('DirectBinaryUploadProcessTest', () => {
             should(fileResults.length).be.exactly(1);
             should(fileResults[0].getRetryErrors().length).be.exactly(1);
         });
+
+        it('trailing slash', async () => {
+            const targetFolder = '/target/folder-trailing-slash';
+            MockRequest.addDirectUpload(targetFolder);
+
+            const options = new DirectBinaryUploadOptions()
+                .withUrl(MockRequest.getUrl(`${targetFolder}/`))
+                .withUploadFiles([{
+                    fileName: 'myasset.jpg',
+                    fileSize: 512,
+                    blob: new MockBlob(),
+                }]);
+            const process = new DirectBinaryUploadProcess({}, options);
+            await process.upload();
+
+            const posts = MockRequest.history.post;
+
+            should(posts.length).be.exactly(2);
+            should(posts[0].url).be.exactly(`${MockRequest.getUrl(targetFolder)}.initiateUpload.json`);
+            should(posts[1].url).be.exactly(`${MockRequest.getUrl(targetFolder)}.completeUpload.json`);
+        });
     });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -14,7 +14,13 @@ const should = require('should');
 
 const { importFile } = require('./testutils');
 
-const { concurrentLoop, exponentialRetry } = importFile('utils');
+const {
+    concurrentLoop,
+    exponentialRetry,
+    trimRight,
+    trimLeft,
+    joinUrlPath
+} = importFile('utils');
 const { DefaultValues } = importFile('constants');
 
 describe('UtilsTest', () => {
@@ -96,5 +102,31 @@ describe('UtilsTest', () => {
             should(count).be.exactly(4);
         }
         should(verified).be.ok();
+    });
+
+    it('test trim right', () => {
+        should(trimRight('/test/', ['/'])).be.exactly('/test');
+        should(trimRight('/test', ['/'])).be.exactly('/test');
+        should(trimRight('/', ['/'])).be.exactly('');
+        should(trimRight('', ['/'])).be.exactly('');
+        should(trimRight(null, ['/'])).be.exactly(null);
+        should(trimRight(1, ['/'])).be.exactly(1);
+        should(trimRight('/trim\\]', ['\\', ']'])).be.exactly('/trim');
+    });
+
+    it('test trim left', () => {
+        should(trimLeft('/test/', ['/'])).be.exactly('test/');
+        should(trimLeft('/test', ['/'])).be.exactly('test');
+        should(trimLeft('/', ['/'])).be.exactly('');
+        should(trimLeft('', ['/'])).be.exactly('');
+        should(trimLeft(null, ['/'])).be.exactly(null);
+        should(trimLeft(1, ['/'])).be.exactly(1);
+        should(trimLeft('\\]trim', ['\\', ']'])).be.exactly('trim');
+    });
+
+    it('test join url path', () => {
+        should(joinUrlPath('1', '2', '3')).be.exactly('/1/2/3');
+        should(joinUrlPath('/1', '/2/', '3/')).be.exactly('/1/2/3');
+        should(joinUrlPath('/', '1', '')).be.exactly('/1');
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Whenever the upload processes uses the `URL` provided in the `withUrl()` method, it will trim any trailing forward slashes from the end of the value.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/adobe/aem-upload/issues/7

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The library should be resilient enough that it can handle URLs that end with a slash. When used in a browser context in particular, this type of value may be given to the library if the browser's address path ends with a slash.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new unit tests to cover the case, and verified that existing unit tests continue to pass. In addition, ran manual tests by passing trailing slashes to the upload process.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
