### PR TITLE
Transfer progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ through the stages of uploading a file. These events are listed below.
                             <td>number</td>
                             <td>
                                 The number of the file's bytes that have been uploaded so far. This will
-                                be a cummulative value, increasing each time the event is sent.
+                                be a cumulative value, increasing each time the event is sent.
                             </td>
                         </tr>
                     </tbody>

--- a/README.md
+++ b/README.md
@@ -517,7 +517,10 @@ through the stages of uploading a file. These events are listed below.
                         <tr>
                             <td>transferred</td>
                             <td>number</td>
-                            <td>The number of the file's bytes that have been uploaded so far.</td>
+                            <td>
+                                The number of the file's bytes that have been uploaded so far. This will
+                                be a cummulative value, increasing each time the event is sent.
+                            </td>
                         </tr>
                     </tbody>
                 </table>

--- a/src/direct-binary-upload-process.js
+++ b/src/direct-binary-upload-process.js
@@ -384,8 +384,7 @@ export default class DirectBinaryUploadProcess extends UploadOptionsBase {
         let totalTransferred = 0;
         if (data.on) {
             data.on('data', chunk => {
-                totalTransferred += chunk.length;
-                this.sendProgressEvent(part, totalTransferred);
+                this.sendProgressEvent(part, chunk.length);
             });
         } else {
             reqOptions.onUploadProgress = progress => {

--- a/test/mock-request.js
+++ b/test/mock-request.js
@@ -45,6 +45,7 @@ const origReset = mock.reset;
 let onInits = {};
 let onParts = {};
 let onCompletes = {};
+let partSize = 512;
 
 /**
  * Calls the default mock axios version of the method, and also resets registered part or complete
@@ -55,7 +56,17 @@ mock.reset = function() {
     onInits = {};
     onParts = {};
     onCompletes = {};
+    partSize = 512;
 };
+
+/**
+ * Sets the size of each part for a file.
+ *
+ * @param {number} newSize The new part size, in bytes.
+ */
+mock.setPartSize = function(newSize) {
+    partSize = newSize;
+}
 
 /**
  * Retrieves the full URL to a file part in the mocked request framework.
@@ -117,9 +128,11 @@ function processInit(targetFolder, config) {
         setTimeout(() => {
             const query = querystring.parse(config.data);
             let fileNames = query.fileName;
+            let fileSizes = query.fileSize;
 
             if (typeof fileNames === 'string') {
                 fileNames = [fileNames];
+                fileSizes = [fileSizes];
             }
             resolve([
                 201,
@@ -127,8 +140,8 @@ function processInit(targetFolder, config) {
                     completeURI: `/content/dam${targetFolder}.completeUpload.json`,
                     folderPath: URL.parse(config.url).pathname,
                     files: fileNames.map((file, index) => {
-                        const fileSize = query.fileSize[index];
-                        const numUris = Math.ceil(fileSize / 512);
+                        const fileSize = fileSizes[index];
+                        const numUris = Math.ceil(fileSize / partSize);
                         const uploadUris = [];
 
                         for (let i = 0; i < numUris; i += 1) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Internal code was incorrectly sending a cumulative value instead of an individual chunk length. This only applies when uploading local files.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/adobe/aem-upload/issues/8

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

File upload progress was being incorrectly reported when uploading local files. Uploading in a browser context was working as expected.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new unit tests, verified that existing unit tests pass, and manually ensured that the transferred value is correct.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
