### PR TITLE
Fix error when uploading to directories containing characters that require URL encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2965,9 +2965,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.2.0",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-desktop-release/handlebars/-/handlebars-4.2.0.tgz",
-      "integrity": "sha1-V86NIXW5u7PYs88+Qhexrsjdyy4=",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.2.tgz",
+      "integrity": "sha512-4PwqDL2laXtTWZghzzCtunQUTLbo31pcCJrd/B/9JP8XbhVzpS5ZXuKqlOzsd1rtcaLo4KqAn8nl8mkknS4MHw==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -2978,8 +2978,8 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-desktop-release/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         }
       }
@@ -4080,8 +4080,8 @@
     },
     "neo-async": {
       "version": "2.6.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-desktop-release/neo-async/-/neo-async-2.6.1.tgz",
-      "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nested-error-stacks": {
@@ -4315,7 +4315,7 @@
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-desktop-release/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
@@ -4325,7 +4325,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-desktop-release/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
@@ -5706,27 +5706,27 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.4.10",
-      "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-desktop-release/uglify-js/-/uglify-js-3.4.10.tgz",
-      "integrity": "sha1-mtlWPY6zrN+404WX0q8dgV9qdV8=",
+      "version": "3.7.6",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.6.tgz",
+      "integrity": "sha512-yYqjArOYSxvqeeiYH2VGjZOqq6SVmhxzaPjJC1W2F9e+bqvFL9QXQ2osQuKUFjM2hGjKG2YclQnRKWQSt/nOTQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.19.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.19.0",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-desktop-release/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha1-9hmKqE5bg8RgVLlN3tv+1e6f8So=",
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true,
           "optional": true
         },
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-desktop-release/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "optional": true
         }

--- a/src/init-response.js
+++ b/src/init-response.js
@@ -87,7 +87,7 @@ export default class InitResponse extends UploadOptionsBase {
         // older versions of the API return absolute URIs for the completeURI. In this case,
         // convert the URI to relative
         if (completeURI) {
-            completeURI = URL.parse(completeURI).pathname;
+            completeURI = URL.parse(encodeURI(completeURI)).pathname;
 
             // remove instance context path, if necessary
             const contentIndex = completeURI.indexOf('/content/dam');

--- a/test/init-response.test.js
+++ b/test/init-response.test.js
@@ -19,8 +19,9 @@ const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
 const UploadFile = importFile('upload-file');
 
 describe('InitResponseTest', () => {
-    it('test get all parts', () => {
+    it.only('test get all parts', () => {
         const uploadFiles = [];
+        const completeURI = 'http://unittestupload.com/￡‰§№￠℡㈱/￡‰§№￠℡㈱.jpg';
 
         for (let i = 0; i < 10; i += 1) {
             const fileName = `testfile${i}.jpg`;
@@ -39,7 +40,7 @@ describe('InitResponseTest', () => {
         const uploadFileInstances = [];
         const initData = {
             files: [],
-            completeURI: 'http://unittestupload.com/complete'
+            completeURI
         }
         uploadOptions.getUploadFiles().forEach(uploadFile => {
             const { fileName } = uploadFile;
@@ -67,5 +68,6 @@ describe('InitResponseTest', () => {
             should(part.getFileName()).be.exactly(fileName);
             should(part.getUrl()).be.exactly(`http://unittestupload.com/${fileName}/${partIndex % 10}`);
         });
+        should(initResponse.getCompleteUri()).be.exactly(encodeURI(completeURI));
     });
 });

--- a/test/init-response.test.js
+++ b/test/init-response.test.js
@@ -19,7 +19,7 @@ const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
 const UploadFile = importFile('upload-file');
 
 describe('InitResponseTest', () => {
-    it.only('test get all parts', () => {
+    it('test get all parts', () => {
         const uploadFiles = [];
         const completeURI = 'http://unittestupload.com/￡‰§№￠℡㈱/￡‰§№￠℡㈱.jpg';
 


### PR DESCRIPTION
## Description

The `completeURI` value provided by the init servlet is not URI encoded. This causes a failure in the upload process when the URI contains characters that _should_ be encoded. The fix is to use `encodeURI()` on the value before sending an HTTP request to the URL.

## Related Issue

#11 

## Motivation and Context

Fixes a bug preventing assets from being uploaded to certain directories.

## How Has This Been Tested?

1. Manually reproduce the issue using most current version of the library.
1. Created a unit test that would cause the same failure.
1. Fixed the issue.
1. Attempted to manually reproduce issue and observed that the failure no longer occurred.
1. Verified that newly created unit test passed.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
