### PR TITLE
use the assets api to create folders

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -210,3 +210,30 @@ export function joinUrlPath(...theArguments) {
 
     return path;
 }
+
+/**
+ * Removes "/content/dam" from the beginning of a given path, if its
+ * present. If the path equals "/content/dam" then the method will
+ * return an empty string.
+ *
+ * @param {string} path The path to trim.
+ */
+export function trimContentDam(path) {
+    if (!path) {
+        return path;
+    }
+
+    if (path === '/content/dam') {
+        return '';
+    }
+
+    let trimmed = String(path);
+    if (trimmed.startsWith('/content/dam/')) {
+        trimmed = trimmed.substr('/content/dam'.length);
+        if (trimmed === '/') {
+            return '';
+        }
+    }
+
+    return trimmed;
+}

--- a/test/filesystem-upload.test.js
+++ b/test/filesystem-upload.test.js
@@ -90,7 +90,7 @@ describe('FileSystemUpload Tests', () => {
             addTestPath('/test/dir/4', 2000);
             addTestPath('/test/dir', 0, ['3', '4']);
 
-            MockRequest.onPost(MockRequest.getUrl('/target')).reply([201]);
+            MockRequest.onPost(MockRequest.getApiUrl('/target')).reply(201);
 
             const uploadOptions = new DirectBinaryUploadOptions()
                 .withUrl(MockRequest.getUrl('/target'))
@@ -118,6 +118,32 @@ describe('FileSystemUpload Tests', () => {
             validateUploadFile(fileLookup['2'], '/test/file/2', 1024);
             validateUploadFile(fileLookup['3'], '/test/dir/3', 2048);
             validateUploadFile(fileLookup['4'], '/test/dir/4', 2000);
+        });
+
+        it('test directory already exists', async () => {
+            MockRequest.onPost(MockRequest.getApiUrl('/existing_target')).reply(409);
+
+            const uploadOptions = new DirectBinaryUploadOptions()
+                .withUrl(MockRequest.getUrl('/existing_target'))
+                .withBasicAuth('testauth');
+            const fsUpload = new FileSystemUpload();
+            return fsUpload.createAemFolder(uploadOptions);
+        });
+
+        it('test directory not found', async () => {
+            MockRequest.onPost(MockRequest.getApiUrl('/existing_target')).reply(404);
+
+            const uploadOptions = new DirectBinaryUploadOptions()
+                .withUrl(MockRequest.getUrl('/existing_target'))
+                .withBasicAuth('testauth');
+            const fsUpload = new FileSystemUpload();
+            let threw = false;
+            try {
+                await fsUpload.createAemFolder(uploadOptions);
+            } catch (e) {
+                threw = true;
+            }
+            should(threw).be.ok();
         });
     });
 });

--- a/test/mock-request.js
+++ b/test/mock-request.js
@@ -41,6 +41,16 @@ mock.getUrl = (targetPath) => {
     return `${mock.getHost()}/content/dam${targetPath}`;
 };
 
+/**
+ * Retrieves a full URL to a target path in the mocked request framework. This URL
+ * will be a path to /api/assets.
+ *
+ * @returns {string} Absolute URL.
+ */
+mock.getApiUrl = (targetPath) => {
+    return `${mock.getHost()}/api/assets${targetPath}`;
+};
+
 const origReset = mock.reset;
 let onInits = {};
 let onParts = {};

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -19,7 +19,8 @@ const {
     exponentialRetry,
     trimRight,
     trimLeft,
-    joinUrlPath
+    joinUrlPath,
+    trimContentDam
 } = importFile('utils');
 const { DefaultValues } = importFile('constants');
 
@@ -128,5 +129,16 @@ describe('UtilsTest', () => {
         should(joinUrlPath('1', '2', '3')).be.exactly('/1/2/3');
         should(joinUrlPath('/1', '/2/', '3/')).be.exactly('/1/2/3');
         should(joinUrlPath('/', '1', '')).be.exactly('/1');
+    });
+
+    it('test trim content dam', () => {
+        should(trimContentDam('/content/dam')).be.exactly('');
+        should(trimContentDam('/content/dam/')).be.exactly('');
+        should(trimContentDam('/content/dam/test')).be.exactly('/test');
+        should(trimContentDam(null)).be.exactly(null);
+        should(trimContentDam('/')).be.exactly('/');
+        should(trimContentDam('/content/dame')).be.exactly('/content/dame');
+        should(trimContentDam('/content/dame/test')).be.exactly('/content/dame/test');
+        should(trimContentDam('/test')).be.exactly('/test');
     });
 });


### PR DESCRIPTION
## Description

Resolution to issue #14, where the library should use the assets api when creating folders instead of using the sling post servlet.

## Related Issue

#14 

## Motivation and Context

There are some cases where using the sling post servlet to create folders can cause issues with the name of the folder. Using the assets api is the recommended approach for creating asset folders in AEM.

## How Has This Been Tested?

Extended unit tests to verify the new creation method. Ran tests using a cloud AEM instance:

* Used a directory that didn't exist and verified that it was created.
* Used a directory that already existed and verified that there were no errors.
* Used /content/dam as the directory and verified the upload succeeded.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x]I have added tests to cover my changes.
- [x] All new and existing tests passed.
