### PR TITLE
Create folder structure

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -230,10 +230,7 @@ export function trimContentDam(path) {
     let trimmed = String(path);
     if (trimmed.startsWith('/content/dam/')) {
         trimmed = trimmed.substr('/content/dam'.length);
-        if (trimmed === '/') {
-            return '';
-        }
     }
 
-    return trimmed;
+    return trimRight(trimmed, ['/']);
 }

--- a/test/filesystem-upload.test.js
+++ b/test/filesystem-upload.test.js
@@ -74,6 +74,7 @@ function addTestPath(path, size, children) {
 describe('FileSystemUpload Tests', () => {
     beforeEach(() => {
         paths = {};
+        MockRequest.reset();
     });
 
     describe('upload', () => {
@@ -144,6 +145,21 @@ describe('FileSystemUpload Tests', () => {
                 threw = true;
             }
             should(threw).be.ok();
+        });
+
+        it('test create directory structure', async () => {
+            MockRequest.onPost(MockRequest.getApiUrl('/folder')).reply(409);
+            MockRequest.onPost(MockRequest.getApiUrl('/folder/structure')).reply(201);
+
+            const uploadOptions = new DirectBinaryUploadOptions()
+                .withUrl(MockRequest.getUrl('/folder/structure'))
+                .withBasicAuth('testauth');
+            const fsUpload = new FileSystemUpload();
+            await fsUpload.createAemFolderStructure(uploadOptions);
+            const { post: posts = [] } = MockRequest.history;
+            should(posts.length).be.exactly(2);
+            should(posts[0].url).be.exactly(MockRequest.getApiUrl('/folder'));
+            should(posts[1].url).be.exactly(MockRequest.getApiUrl('/folder/structure'));
         });
     });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -136,9 +136,10 @@ describe('UtilsTest', () => {
         should(trimContentDam('/content/dam/')).be.exactly('');
         should(trimContentDam('/content/dam/test')).be.exactly('/test');
         should(trimContentDam(null)).be.exactly(null);
-        should(trimContentDam('/')).be.exactly('/');
+        should(trimContentDam('/')).be.exactly('');
         should(trimContentDam('/content/dame')).be.exactly('/content/dame');
         should(trimContentDam('/content/dame/test')).be.exactly('/content/dame/test');
         should(trimContentDam('/test')).be.exactly('/test');
+        should(trimContentDam('/test/')).be.exactly('/test');
     });
 });


### PR DESCRIPTION
## Description

Added functionality to the file upload feature so that the target AEM folder, and all of its ancestors, are created if they don't exist.

## Related Issue

#13 

## Motivation and Context

Sometimes consumer may want to upload to folders that don't exist yet. Rather than requiring them to create the folders beforehand, the tool will now create them automatically.

## How Has This Been Tested?

* Added unit tests for the new feature.
* Uploaded to a folder that already exists.
* Uploaded to a folder whose ancestors already exist.
* Uploaded to a folder whose ancestors did not already exist.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
