### PR TITLE
set cookies specified by server to allow sticky sessions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2744,6 +2744,11 @@
         }
       }
     },
+    "cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://artifactory.corp.adobe.com:443/artifactory/api/npm/npm-aem-desktop-release/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -6832,9 +6837,9 @@
       }
     },
     "yargs-parser": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+      "version": "13.1.2",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "async": "^3.2.0",
     "axios": "^0.19.2",
+    "cookie": "^0.4.1",
     "core-js": "^3.6.4",
     "filesize": "^4.2.1",
     "regenerator-runtime": "^0.13.5"

--- a/src/direct-binary-upload-options.js
+++ b/src/direct-binary-upload-options.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import URL from 'url';
+import cookie from 'cookie';
 
 import DirectBinaryUploadController from './direct-binary-upload-controller';
 import { trimRight } from './utils';
@@ -83,6 +84,39 @@ export default class DirectBinaryUploadOptions {
             ...headers,
         };
         return this;
+    }
+
+    /**
+     * The given cookies will be merged with any cookies specified previously using the
+     * method.
+     *
+     * @param {object} cookies Keys should be cookie names, values should be the cookie's value.
+     * @returns {DirectBinaryUploadOptions} The current options instance. Allows for chaining.
+     */
+    withCookies(cookies) {
+        const headers = this.getHeaders() || {};
+        const existingCookies = cookie.parse(headers.Cookie || '');
+        let cookieString = '';
+
+        Object.keys(existingCookies).forEach(toSerialize => {
+            if (!cookies[toSerialize]) {
+                if (cookieString) {
+                    cookieString += '; ';
+                }
+                cookieString += cookie.serialize(toSerialize, existingCookies[toSerialize]);
+            }
+        });
+
+        Object.keys(cookies).forEach(toSerialize => {
+            if (cookieString) {
+                cookieString += '; ';
+            }
+            cookieString += cookie.serialize(toSerialize, cookies[toSerialize]);
+        });
+
+        return this.withHeaders({ 
+            Cookie: cookieString
+        });
     }
 
     /**

--- a/src/direct-binary-upload-process.js
+++ b/src/direct-binary-upload-process.js
@@ -20,7 +20,11 @@ import UploadError from './upload-error';
 import ErrorCodes from './error-codes';
 import FileUploadResult from './file-upload-result';
 import PartUploadResult from './part-upload-result';
-import { timedRequest, createCancelToken } from './http-utils';
+import { 
+    timedRequest,
+    createCancelToken,
+    updateOptionsWithResponse,
+} from './http-utils';
 import {
     concurrentLoop,
     serialLoop,
@@ -50,7 +54,7 @@ export default class DirectBinaryUploadProcess extends UploadOptionsBase {
      * @returns {Promise} Resolved with an UploadResult instance when the process has finished.
      */
     async upload() {
-        const options = this.getUploadOptions();
+        let options = this.getUploadOptions();
         const url = options.getUrl();
         const targetFolder = options.getTargetFolderPath();
         const toUpload = options.getUploadFiles().map(upload => new UploadFile(this.getOptions(), options, upload));
@@ -87,6 +91,7 @@ export default class DirectBinaryUploadProcess extends UploadOptionsBase {
                 status: statusCode,
                 elapsedTime = 0,
             } = response;
+            options = updateOptionsWithResponse(options, response);
 
             this.logInfo(`Finished initialize uploading, response code: '${statusCode}', time elapsed: '${elapsedTime}' ms`);
 

--- a/src/http-utils.js
+++ b/src/http-utils.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 import axios, { CancelToken } from 'axios';
+import cookie from 'cookie';
 
 import UploadError from './upload-error';
 import { exponentialRetry } from './utils';
@@ -64,4 +65,24 @@ export async function timedRequest(requestOptions, retryOptions, cancelToken) {
     } catch (e) {
         throw UploadError.fromError(e);
     }
+}
+
+/**
+ * Does any necessary work to update an existing options object with the results
+ * of an HTTP response. For example, if the response contains a set-cookie header
+ * then the cookies will be added to the options.
+ *
+ * @param {DirectBinaryUploadOptions} options Options to update.
+ * @param {object} response A response object from an HTTP request.
+ * @returns {DirectBinaryUploadOptions} Options with updated values.
+ */
+export function updateOptionsWithResponse(options, response) {
+    const { headers = {} } = response;
+    const setCookie = headers['set-cookie'];
+
+    if (setCookie && setCookie.length) {
+        return options.withCookies(cookie.parse(setCookie[0]));
+    }
+
+    return options;
 }

--- a/test/direct-binary-upload-options.test.js
+++ b/test/direct-binary-upload-options.test.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const should = require('should');
+const cookie = require('cookie');
 
 const { importFile } = require('./testutils');
 
@@ -24,5 +25,21 @@ describe('DirectBinaryUploadOptionsTest', () => {
         should(options.getUrl()).be.exactly('/');
         options.withUrl('/trailing/');
         should(options.getUrl()).be.exactly('/trailing');
+    });
+
+    it('test cookies', () => {
+        let options = new DirectBinaryUploadOptions()
+            .withCookies({ cookie: 'value' });
+
+        let cookies = cookie.parse(options.getHeaders()['Cookie']);
+        should(cookies).be.ok();
+        should(cookies.cookie).be.exactly('value');
+
+        options = options.withCookies({ cookie: 'value2', anotherCookie: 'another' });
+        cookies = cookie.parse(options.getHeaders()['Cookie']);
+        should(cookies).be.ok();
+        should(cookies.cookie).be.exactly('value2');
+        should(cookies.anotherCookie).be.exactly('another');
+        console.log(options.getHeaders());
     });
 });

--- a/test/http-utils.test.js
+++ b/test/http-utils.test.js
@@ -11,11 +11,13 @@ governing permissions and limitations under the License.
 */
 
 const should = require('should');
+const cookie = require('cookie');
 
 const { importFile } = require('./testutils');
 const MockRequest = require('./mock-request');
+const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
 
-const { timedRequest } = importFile('http-utils');
+const { timedRequest, updateOptionsWithResponse } = importFile('http-utils');
 
 describe('HttpUtilsTest', () => {
     beforeEach(() => {
@@ -42,5 +44,16 @@ describe('HttpUtilsTest', () => {
             should(status).be.exactly(200);
             should(elapsedTime >= 100).be.ok();
         });
+    });
+
+    it('test update options', () => {
+        let options = new DirectBinaryUploadOptions();
+        options = updateOptionsWithResponse(options, {});
+        should(options.getHeaders().Cookie).not.be.ok();
+        options = updateOptionsWithResponse(options, { headers: { 'set-cookie': [] } });
+        should(options.getHeaders().Cookie).not.be.ok();
+        options = updateOptionsWithResponse(options, { headers: { 'set-cookie': [cookie.serialize('cookie', 'value')]} });
+        should(options.getHeaders().Cookie).be.ok();
+        should(cookie.parse(options.getHeaders().Cookie).cookie).be.exactly('value');
     });
 });


### PR DESCRIPTION
## Description

This is a resolution to #17. The library will now use any cookies provided in the `set-cookie` header of server responses.

## Related Issue

See #17.

## Motivation and Context

Per the ticket, there are cases where the target container may change part way through multiple file uploads. This fix will support "sticky" sessions, which should ensure that the target container remains the same through the upload process.

## How Has This Been Tested?

* Added new unit tests to cover case.
* Manually uploaded files from the command line to ensure the process still works.

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
