### PR TITLE
add functionality for walking directories and then uploading them.

### DIFF
--- a/src/filesystem-upload-options.js
+++ b/src/filesystem-upload-options.js
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import DirectBinaryUploadOptions from './direct-binary-upload-options';
+import { DefaultValues } from './constants';
+
+/**
+ * Options specific to a file system upload. Also supports all options defined by
+ * DirectBinaryUploadOptions.
+ */
+export default class FileSystemUploadOptions extends DirectBinaryUploadOptions {
+
+    /**
+     * Creates a new FileSystemUploadOptions instance that will have the same options
+     * as an existing options instance.
+     * @param {DirectBinaryUploadOptions} uploadOptions Options whose value should
+     *  be copied.
+     */
+    static fromOptions(uploadOptions) {
+        const newOptions = new FileSystemUploadOptions();
+        newOptions.options = { ...uploadOptions.options };
+        newOptions.controller = uploadOptions.controller;
+        return newOptions;
+    }
+
+    /**
+     * Sets the maximum number of files that can be uploaded using the module at one time. If
+     * the total number of files exceeds this number then the library will throw an exception
+     * with code TOO_LARGE.
+     * @param {*} maxFileCount 
+     * @returns {FileSystemUploadOptions} The current options instance. Allows for chaining.
+     */
+    withMaxUploadFiles(maxFileCount) {
+        this.options.maxUploadFiles = maxFileCount;
+        return this;
+    }
+
+    /**
+     * Sets a value indicating whether or not the process should upload all descendent
+     * directories and files within the given directory.
+     * @param {boolean} deepUpload True if the upload should be deep, false otherwise.
+     * @returns {FileSystemUploadOptions} The current options instance. Allows for chaining.
+     */
+    withDeepUpload(deepUpload) {
+        this.options.deepUpload = deepUpload;
+        return this;
+    }
+
+    /**
+     * Retrieves the maximum number of files that the module can upload in a single upload
+     * request.
+     *
+     * @returns {number} Maximum file count.
+     */
+    getMaxUploadFiles() {
+        return this.options.maxUploadFiles || DefaultValues.MAX_FILE_UPLOAD;
+    }
+
+    /**
+     * Retrieves a value indicating whether the process should upload all descendent
+     * directories and files within the given directory.
+     * @returns {boolean} True for a deep upload, false otherwise.
+     */
+    getDeepUpload() {
+        return !!this.options.deepUpload;
+    }
+
+}

--- a/src/filesystem-upload-utils.js
+++ b/src/filesystem-upload-utils.js
@@ -1,0 +1,102 @@
+/*
+Copyright 2020 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import Path from 'path';
+
+import { DefaultValues } from './constants';
+import { normalizePath } from './utils';
+
+/**
+ * Retrieves the option indicating whether or not the upload is deep. Takes
+ * into account that the options might not be FileSystemUploadOptions.
+ * @param {FileSystemUploadOptions|DirectBinaryUploadOptions} uploadOptions Options
+ *  to retrieve value from.
+ * @returns {boolean} True if it's a deep upload, false otherwise.
+ */
+function isDeepUpload(uploadOptions) {
+    if (!uploadOptions.getDeepUpload) {
+        // default to false if the class received an options instance
+        // not of type FileSystemUploadOptions.
+        return false;
+    }
+    return uploadOptions.getDeepUpload();
+}
+
+/**
+ * Retrieves the remote path for an item to upload. Removes a local
+ * prefix from its path, then appends the result to the target
+ * path from the given options.
+ *
+ * @param {DirectBinaryUploadOptions} uploadOptions Will be used to determine
+ *  the behavior of the method.
+ * @param {string} removePathPrefix Will be removed from the given local path
+ *  if present.
+ * @param {string} localPath Full path to a local item.
+ * @returns {string} Remote path to the item.
+ */
+function getItemRemoteUrl(uploadOptions, removePathPrefix, localPath) {
+    const nRemovePathPrefix = normalizePath(removePathPrefix);
+    const nLocalPath = normalizePath(localPath);
+    const targetRoot = uploadOptions.getUrl();
+    const isDeep = isDeepUpload(uploadOptions);
+
+    if (isDeep && removePathPrefix && String(nLocalPath).startsWith(`${nRemovePathPrefix}/`)) {
+        return `${targetRoot}${nLocalPath.substr(nRemovePathPrefix.length)}`;
+    }
+
+    return `${targetRoot}/${Path.basename(localPath)}`;
+}
+
+/**
+ * Separates a list of files into a lookup based on its target remote path.
+ *
+ * @param {Array} files List of simple objects representing files. Is
+ *  expected to at least have a "path" element.
+ * @returns {object} Simple object whose keys are directory paths; values
+ *  are an Array of objects as-is from the files parameter.
+ */
+function aggregateByRemoteDirectory(files) {
+    const directoryAggregate = {};
+
+    files.forEach(file => {
+        const { remoteUrl } = file;
+        const remoteDirectory = remoteUrl.substr(0, remoteUrl.lastIndexOf('/'));
+
+        if (!directoryAggregate[remoteDirectory]) {
+            directoryAggregate[remoteDirectory] = [];
+        }
+        directoryAggregate[remoteDirectory].push(file);
+    });
+    return directoryAggregate;
+}
+
+/**
+ * Retrieves the option specifying the maximum number of files that can be
+ * uploaded at once. Takes into account that the options might not be
+ * FileSystemUploadOptions.
+ * @param {FileSystemUploadOptions|DirectBinaryUploadOptions} uploadOptions Options
+ *  to retrieve value from.
+ * @returns {number} Maximum number of files to upload.
+ */
+function getMaxFileCount(uploadOptions) {
+    if (!uploadOptions.getMaxUploadFiles) {
+        return DefaultValues.MAX_FILE_UPLOAD;
+    }
+    return uploadOptions.getMaxUploadFiles();
+}
+
+module.exports = {
+    getItemRemoteUrl,
+    aggregateByRemoteDirectory,
+    isDeepUpload,
+    getMaxFileCount,
+}

--- a/src/filesystem-upload.js
+++ b/src/filesystem-upload.js
@@ -10,56 +10,42 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import fs from 'fs';
-import path from 'path';
-import axios from 'axios';
+import { promises as fs } from 'fs';
+import Path from 'path';
+import { v4 as uuid } from 'uuid';
 
-import UploadBase from './upload-base';
 import DirectBinaryUpload from './direct-binary-upload';
-import { trimContentDam } from './utils';
-import { updateOptionsWithResponse } from './http-utils';
+import DirectBinaryUploadProcess from './direct-binary-upload-process';
+import FileSystemUploadOptions from './filesystem-upload-options';
+import {
+    trimContentDam,
+    walkDirectory,
+    isTempPath,
+    concurrentLoop
+} from './utils';
+import {
+    updateOptionsWithResponse,
+} from './http-utils';
+import UploadError from './upload-error';
+import ErrorCodes from './error-codes';
+import UploadResult from './upload-result';
+import HttpClient from './http/http-client';
+import ConcurrentQueue from './concurrent-queue';
+import PartUploader from './part-uploader';
+import HttpRequest from './http/http-request';
+import {
+    getItemRemoteUrl,
+    aggregateByRemoteDirectory,
+    isDeepUpload,
+    getMaxFileCount,
+} from './filesystem-upload-utils';
 
-/**
- * Promise-ified version of fs.stat().
- *
- * @param {string} path Path to the item to stat.
- * @returns {Promise} Resolved with the item's stat information, or rejected with
- *  an error.
- */
-function statPromise(path) {
-    return new Promise((resolve, reject) => {
-        fs.stat(path, (err, stat) => {
-            if (err) {
-                reject(err);
-                return;
-            }
-            resolve(stat);
-        });
-    });
-}
-
-/**
- * Promise-ified version of fs.readdir().
- *
- * @param {string} path Path to the directory to read.
- * @returns {Promise} Resolved with a list of item names in the directory, or rejected with an error.
- */
-function readDirPromise(path) {
-    return new Promise((resolve, reject) => {
-        fs.readdir(path, (err, results) => {
-            if (err) {
-                reject(err);
-                return;
-            }
-            resolve(results);
-        });
-    });
-}
+const MAX_CONCURRENT_DIRS = 10;
 
 /**
  * Uploads one or more files from the local file system to a target AEM instance using direct binary access.
  */
-export default class FileSystemUpload extends UploadBase {
+export default class FileSystemUpload extends DirectBinaryUpload {
     /**
      * Retrieves information from the local file system for a list of files, creates a new directory in
      * AEM, then uploads each of the local files to the new directory using direct binary access.
@@ -71,85 +57,203 @@ export default class FileSystemUpload extends UploadBase {
      *  passed in successful resolution will be an instance of UploadResult.
      */
     async upload(options, localPaths) {
-        const folderOptions = await this.createAemFolderStructure(options);
+        const httpClient = new HttpClient(this.getOptions(), options);
+        const concurrentQueue = new ConcurrentQueue(this.getOptions(), options);
+        const partUploader = new PartUploader(this.getOptions(), options, httpClient, concurrentQueue);
+        const uploadResult = new UploadResult(this.getOptions(), options);
+        await this.createTargetFolder(options, httpClient);
+        const {
+            directories,
+            files,
+            errors,
+            totalSize
+        } = await this.getUploadInformation(options, localPaths);
+    
+        this.logInfo(`From ${localPaths.length} paths, filesystem upload compiled upload of ${directories.length} directories, ${files.length} files, with a total size of ${totalSize}. Encountered ${errors.length} filesystem-related errors.`);
 
-        // start initiate uploading, single for all files
-        const directUpload = new DirectBinaryUpload(this.options);
-        const uploadOptions = folderOptions
-            .withAddContentLengthHeader(true)
-            .withUploadFiles(await this.getUploadFiles(localPaths));
+        const uploadId = uuid();
+        const uploadEventData = {
+            uploadId,
+            fileCount: files.length,
+            directoryCount: directories.length,
+            totalSize
+        };
+        this.sendEvent('fileuploadstart', uploadEventData);
 
-        return await directUpload.uploadFiles(uploadOptions);
+        await this.createUploadDirectories(options, httpClient, directories);
+
+        // the algorithm will "init" an upload for each directory (since the initialization process
+        // is directory based). Group the full list of files by their target directory so that all files
+        // in a directory can be initialized at the same time
+        const aggregatedFiles = aggregateByRemoteDirectory(files);
+        const directoriesWithFiles = Object.keys(aggregatedFiles);
+
+        // leave concurrency up to the upload process itself. The bottleneck should be there, not
+        // in the number of directories to upload at a time.
+        await concurrentLoop(directoriesWithFiles, MAX_CONCURRENT_DIRS, async (directoryUrl) => {
+            const targetFiles = aggregatedFiles[directoryUrl];
+            const uploadFiles = this.convertToUploadFiles(targetFiles);
+
+            this.logInfo(`Uploading ${uploadFiles.length} files to directory ${directoryUrl}`);
+
+            // start initiate uploading, single for all files in the current directory
+            const uploadOptions = FileSystemUploadOptions.fromOptions(options)
+                .withUrl(directoryUrl)
+                .withUploadFiles(uploadFiles);
+
+            const uploadProcess = new DirectBinaryUploadProcess(this.getOptions(), uploadOptions, httpClient, partUploader);
+
+            uploadProcess.on('filestart', data => this.sendEvent('filestart', data));
+            uploadProcess.on('fileprogress', data => this.sendEvent('fileprogress', data));
+            uploadProcess.on('fileend', data => this.sendEvent('fileend', data));
+            uploadProcess.on('fileerror', data => this.sendEvent('fileerror', data));
+            uploadProcess.on('filecancelled', data => this.sendEvent('filecancelled', data));
+
+            try {
+                await uploadProcess.upload(uploadResult);
+            } catch (uploadError) {
+                uploadResult.addUploadError(uploadError);
+            }
+        });
+
+        this.sendEvent('fileuploadend', {
+            ...uploadEventData,
+            result: uploadResult.toJSON()
+        });
+
+        // we have a list of multiple results (for each directory upload). Merge all those
+        // into a single result that contains metrics for the overall upload of all
+        // directories and files.
+        return uploadResult;
     }
 
     /**
-     * Retrieves a flat list of files based on file paths. If a path is a file it will be added to the returned array.
-     * If a path is a directory then all files immediately beneath the directory will be added to the returned array.
-     *
-     * @param {Array} fromArr List of local file system paths.
-     * @returns {Promise} Will be resolved with an array containing a flat list of simple objects ready to be passed to the
-     *  constructor of UploadFile.
+     * Converts a list of files, as retrieved by getUploadInformation(), to a list
+     * of UploadFile items, ready for use in upload options.
+     * @param {Array} files List of files as retrieved by getUploadInformation().
+     * @returns {Array} List of files ready for use with DirectBinaryUploadOptions.withUploadFiles().
      */
-    async getUploadFiles(fromArr) {
-        let fileList = [];
+    convertToUploadFiles(files) {
+        const fileList = [];
 
-        for (let i = 0; i < fromArr.length; i += 1) {
-            const item = fromArr[i];
-            let fileStat;
+        files.forEach(file => {
+            const { path, size } = file;
+            fileList.push({
+                fileName: Path.basename(path),
+                filePath: path,
+                fileSize: size
+            })
+        });
 
-            try {
-                fileStat = await statPromise(item);
-            } catch (e) {
-                this.logWarn(`The specified '${item}' doesn't exists`);
-            }
-
-            if (fileStat) {
-                if (fileStat.isFile()) {
-                    let fileName = path.basename(item);
-                    let fileSize = fileStat.size;
-                    fileList.push({
-                        fileName,
-                        filePath: item,
-                        fileSize,
-                    });
-                } else if (fileStat.isDirectory()) {
-                    let subFileArr = await readDirPromise(item);
-
-                    for (let d = 0; d < subFileArr.length; d += 1) {
-                        const fileName = subFileArr[d];
-                        let filePath = path.join(item, fileName);
-                        let subFileStat = await statPromise(filePath);
-                        if (subFileStat.isFile()) {
-                            if (fileName.match(/^\./)) {
-                                this.logDebug('Skip hidden file: ' + fileName);
-                            } else {
-                                let fileSize = subFileStat.size;
-                                fileList.push({
-                                    fileName: fileName,
-                                    filePath: filePath,
-                                    fileSize: fileSize
-                                });
-                            }
-                        } else {
-                            this.logDebug('Skip non file: ' + fileName);
-                        }
-                    }
-                }
-            }
-        }
-
-        this.logInfo('Local files for uploading: ' + JSON.stringify(fileList, null, 4));
         return fileList;
     }
 
     /**
-     * Creates a folder and all of its parents if they do not already exist.
+     * Iterates over a list of local paths provided to the upload. If a path is a file, it will
+     * be added to a master list of all paths to upload. If a path is a directory, the method
+     * will (recursively) iterate over all descendent directories and files in the path and add
+     * them to the master list of paths to upload.
+     * @param {DirectBinaryUploadOptions} options Controls how the upload behaves. Will be used to
+     *  determine the maximum number of files to upload.
+     * @param {Array} localPaths List of local paths to iterate.
+     * @returns {object} Aggregated information about all paths to be included in the upload. Has
+     *  the following elements:
+     *  * {Array} directories: List of full paths to all directories included in the upload.
+     *  * {Array} files: List of full paths to all files included in the upload.
+     *  * {Array} errors: List of any errors that occurred during processing, which may result in
+     *    some paths being excluded from the final result.
+     *  * {number} totalSize: Size, in bytes, of all files included in the upload.
+     *  * {boolean} isDirectory: True if the path is a directory, false otherwise.
+     */
+    async getUploadInformation(options, localPaths) {
+        let allFiles = [];
+        let allDirectories = [];
+        let allErrors = [];
+        let allTotalSize = 0;
+        const isDeep = isDeepUpload(options);
+
+        for (let i = 0; i < localPaths.length; i++) {
+            const currPath = localPaths[i];
+            if (!isTempPath(currPath)) {
+                let stat = false;
+                
+                try {
+                    stat = await fs.stat(localPaths[i]);
+                } catch (e) {
+                    allErrors.push(e);
+                    continue;
+                }
+                if (stat.isDirectory()) {
+                    const {
+                        directories,
+                        files,
+                        errors,
+                        totalSize
+                    } = await walkDirectory(currPath, getMaxFileCount(options), isDeep);
+                    // base sub-item remote paths on current path's parent so that they end up in
+                    // the correct directory
+                    const currPathParent = Path.dirname(currPath);
+                    if (isDeep) {
+                        // directories only need to be included for deep uploads
+                        allDirectories.push({ remoteUrl: getItemRemoteUrl(options, '', currPath), path: currPath });
+                        allDirectories = allDirectories.concat(directories.map(dirItem => {
+                            const { path: dirPath } = dirItem;
+                            return { remoteUrl: getItemRemoteUrl(options, currPathParent, dirPath), path: dirPath };
+                        }));
+                    }
+                    allFiles = allFiles.concat(files.map(fileItem => {
+                        const { path: filePath, size: fileSize } = fileItem;
+                        return { remoteUrl: getItemRemoteUrl(options, currPathParent, filePath), path: filePath, size: fileSize };
+                    }));
+                    allErrors = allErrors.concat(errors);
+                    allTotalSize += totalSize;
+                } else if (stat.isFile()) {
+                    allFiles.push({ remoteUrl: getItemRemoteUrl(options, '', currPath), path: currPath, size: stat.size });
+                    allTotalSize += stat.size;
+                }
+            }
+
+            const maxFileCount = getMaxFileCount(options);
+            if (allFiles.length > maxFileCount) {
+                throw new UploadError(`File system upload has exceeded maximum of ${maxFileCount} allowed files`, ErrorCodes.TOO_LARGE);
+            }
+        }
+
+        return {
+            directories: allDirectories,
+            files: allFiles,
+            errors: allErrors,
+            totalSize: allTotalSize
+        };
+    }
+
+    /**
+     * Given path information for a local path upload, creates all the directories required to
+     * complete the upload. The method will iterate all of the paths in the given information,
+     * create the path itself if it's a directory, and create all of of descendent directories.
+     * @param {DirectBinaryUploadOptions} options Target folder information used to determine
+     *  location where directories should be created.
+     * @param {HttpClient} httpClient Client to use to submit HTTP requests.
+     * @param {Array} directories An array of simple objects containing a "remoteUrl" and "path"
+     *  element.
+     */
+    async createUploadDirectories(options, httpClient, directories) {
+        for (let i = 0; i < directories.length; i++) {
+            const { remoteUrl, path } = directories[i];
+
+            this.logInfo(`Creating AEM directory ${remoteUrl} for directory ${path}`);
+            await this.createAemFolder(options, httpClient, new URL(remoteUrl).pathname);
+        }
+    }
+
+    /**
+     * Creates the target folder from upload options and all of its parents if they do not already exist.
      * @param {DirectBinaryUploadOptions} options Options controlling how the upload process behaves.
+     * @param {HttpClient} httpClient Client to use to submit HTTP requests.
      * @returns {Promise} Will be resolved if the folders are created successfully, otherwise will be
      *  rejected with an error.
      */
-    async createAemFolderStructure(options) {
-        let returnOptions = options;
+    async createTargetFolder(options, httpClient) {
         const targetFolder = options.getTargetFolderPath();
         const trimmedFolder = trimContentDam(targetFolder);
 
@@ -159,62 +263,48 @@ export default class FileSystemUpload extends UploadBase {
 
             for (let i = 0; i < paths.length; i += 1) {
                 currPath += `/${paths[i]}`;
-                returnOptions = await this.createAemFolder(options, currPath);
+                await this.createAemFolder(options, httpClient, currPath);
             }
-            
         }
-        return returnOptions;
     }
 
     /**
      * Creates a folder in AEM if it does not already exist.
      *
      * @param {DirectBinaryUploadOptions} options Options controlling how the upload process behaves.
+     * @param {HttpClient} httpClient Client to use to submit HTTP requests.
      * @param {string} [folderPath] If specified, the path of the folder to create. If not specified, the
      *  target folder in the provided options will be used.
      * @returns {Promise} Will be resolved if the folder is created successfully, otherwise will be rejected
      *  with an error.
      */
-    async createAemFolder(options, folderPath = '') {
-        let returnOptions = options;
+    async createAemFolder(options, httpClient, folderPath = '') {
         const targetFolder = folderPath ? folderPath : options.getTargetFolderPath();
-        const headers = options.getHeaders();
         const trimmedFolder = trimContentDam(targetFolder);
 
         if (trimmedFolder) {
-            const folderName = path.basename(trimmedFolder);
+            const folderName = Path.basename(trimmedFolder);
             try {
-                const response = await axios({
-                    url: `${options.getUrlPrefix()}/api/assets${trimmedFolder}`,
-                    method: 'POST',
-                    headers,
-                    data: {
+                const createFolderRequest = new HttpRequest(this.getOptions(), `${options.getUrlPrefix()}/api/assets${trimmedFolder}`)
+                    .withMethod(HttpRequest.Method.POST)
+                    .withData({
                         class: 'assetFolder',
                         properties: {
                             title: folderName
                         }
-                    }
-                });
-                returnOptions = updateOptionsWithResponse(options, response);
+                    })
+                    .withUploadOptions(options);
+                const response = await httpClient.submit(createFolderRequest);
+                updateOptionsWithResponse(options, response);
             } catch (e) {
-                let rethrow = true;
-                if (e) {
-                    const { response = {} } = e;
-                    const { status } = response;
-
-                    if (status === 409) {
-                        rethrow = false;
-                        this.logInfo(`AEM target folder '${targetFolder}' already exists`);
-                    }
+                if (e && e.code == ErrorCodes.ALREADY_EXISTS) {
+                    this.logInfo(`AEM folder '${targetFolder}' already exists`);
+                    return;
                 }
-
-                if (rethrow) {
-                    throw e;
-                }
+                throw e;
             }
         }
 
-        this.logInfo(`AEM target folder '${targetFolder}' is created`);
-        return returnOptions;
+        this.logInfo(`AEM folder '${targetFolder}' is created`);
     }
 }

--- a/src/upload-error.js
+++ b/src/upload-error.js
@@ -136,6 +136,8 @@ export default class UploadError extends Error {
             return 401;
         } else if (code === errorCodes.NOT_FOUND) {
             return 404;
+        } else if (code === errorCodes.TOO_LARGE) {
+            return 413;
         } else if (code === errorCodes.NOT_SUPPORTED) {
             return 501;
         } else {

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,9 +10,32 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+import { promises as fs } from 'fs';
 import Async from 'async';
+import Path from 'path';
 
 import { DefaultValues } from './constants';
+import UploadError from './upload-error';
+import ErrorCodes from './error-codes';
+
+const TEMP_PATTERNS = [
+    /^\/~(.*)/, // catch all paths starting with ~
+    /^\/\.(.*)/, // catch all paths starting with .
+];
+
+const TEMP_NAME_PATTERNS = [
+    /^[.~]/i,
+    /^TestFile/, // InDesign: on file open, InDesign creates .dat.nosync* file, renames it TestFile, and deletes it
+    /\.tmp$/i, // Illustrator: on save, creates one or more *.tmp files, renames them to original file name
+    /\.~tmp$/i, // some default Windows applications use this file format
+    // OS X
+    /^DCIM/,
+    // Windows
+    /^desktop\.ini/i,
+    /^Thumbs\.db/i,
+    /^Adobe Bridge Cache\.bc$/i,
+    /^Adobe Bridge Cache\.bct$/i,
+];
 
 /**
  * Loops through a given array, concurrently invoking the given callback. The loop will have a maximum
@@ -233,4 +256,190 @@ export function trimContentDam(path) {
     }
 
     return trimRight(trimmed, ['/']);
+}
+
+/**
+ * Normalizes a path by ensuring it only contains forward slashes abd does not end with a
+ * slash. If the given path is falsy then the method will return an empty string.
+ * @param {string} path An item's full path.
+ * @returns {string} Normalized version of a path.
+ */
+export function normalizePath(path) {
+    let normPath = path;
+    if (normPath) {
+        normPath = normPath.replace(/\\/g, '/');
+        if (normPath.charAt(normPath.length - 1) === '/') {
+            normPath = normPath.substr(0, normPath.length - 1);
+        }
+    }
+    return normPath || '';
+}
+
+/**
+ * Determines whether or not a given path is either a temp file, or in a temp directory.
+ * @param {string} path A file system-like path.
+ * @returns {boolean} True if the path is a temp file, false otherwise.
+ */
+export function isTempPath(path) {
+    const tempPath = normalizePath(path);
+
+    if (tempPath === '/') {
+        return false;
+    }
+
+    let isTemp = TEMP_PATTERNS.some(pattern => pattern.test(tempPath));
+
+    if (!isTemp) {
+        const pathName = Path.basename(tempPath);
+        isTemp = TEMP_NAME_PATTERNS.some(pattern => pattern.test(pathName));
+    }
+
+    return isTemp;
+}
+
+/**
+ * Concurrently loops through all items in a directory, doing a stat
+ * on each to determine if it's a directory or file. The method will
+ * skip temp files and directories.
+ * @param {string} directoryPath Full path to the directory to iterate.
+ * @returns {object} Simple object containing the following elements:
+ *  {Array} directories: Full path to all directories beneath the given
+ *   directory. The list is not guaranteed to be sorted, but it's guaranteed
+ *   that parent directories will always come before their sub directories.
+ *  {Array} files: Full path to all files beneath the given directory. The list
+ *   is not guaranteed to be sorted, but it's guaranteed that files higher in
+ *   the directory hierarchy will always come before those lower in the hierarchy.
+ *  {number} totalSize: Total size, in bytes, of all files in the directory.
+ */
+async function processDirectory(directoryPath) {
+    let contents = false;
+    
+    const directories = [];
+    const files = [];
+    const errors = [];
+    let totalSize = 0;
+    let includeDirectory = false;
+
+    try {
+        contents = await fs.readdir(directoryPath);
+    } catch (e) {
+        errors.push(e);
+    }
+
+    if (contents) {
+        await concurrentLoop(contents, async (childPath) => {
+            const fullChildPath = Path.join(directoryPath, childPath);
+            if (!isTempPath(fullChildPath)) {
+                let childStat;
+                try {
+                    childStat = await fs.stat(fullChildPath);
+                } catch (e) {
+                    errors.push(e);
+                    return;
+                }
+
+                if (childStat.isDirectory()) {
+                    directories.push({ path: fullChildPath });
+                    includeDirectory = true;
+                } else if (childStat.isFile()) {
+                    files.push({ path: fullChildPath, size: childStat.size });
+                    totalSize += childStat.size;
+                    includeDirectory = true;
+                }
+            }
+        });
+    }
+
+    return {
+        directories,
+        files,
+        errors,
+        totalSize,
+        includeDirectory
+    };
+}
+
+function removeFromArray(valueToRemove, array) {
+    for (let i = 0; i < array.length; i++) {
+        if (array[i].path === valueToRemove) {
+            array.splice(i, 1);
+            return;
+        }
+    }
+}
+
+function removeEmptyDirectories(directories, files) {
+    const validDirectories = [];
+    for (let d = 0; d < directories.length; d++) {
+        const directory = directories[d];
+        const directoryPrefix = Path.join(directory.path, '/');
+        for (let f = 0; f < files.length; f++) {
+            const file = files[f];
+            if (file.path.startsWith(directoryPrefix)) {
+                validDirectories.push(directory);
+                break;
+            }
+        }
+    }
+    
+    return validDirectories;
+}
+
+/**
+ * Walks a directory by retrieving all the directories and files
+ * in the given path, then walking all those sub directories, then
+ * all sub directories of those sub directories, etc. The end result
+ * will be the entire tree, including all descendents, for the
+ * target directory.
+ * @param {string} directoryPath Directory to traverse.
+ * @param {number} [maximumPaths] The maximum number of paths to
+ *  process before the method gives up and throws an exception.
+ *  Default value is 5000.
+ * @param {boolean} [includeDescendents] If true, the method will walk
+ *  descendent directories. If false, the method will only include files
+ *  immediately below the given directory. Default value is true.
+ */
+export async function walkDirectory(directoryPath, maximumPaths = 5000, includeDescendents = true) {
+    let processDirectories = [{ path: directoryPath }];
+    let allDirectories = [];
+    let allFiles = [];
+    let allErrors = [];
+    let walkedTotalSize = 0;
+
+    // this algorithm avoids recursion to prevent overflows. Instead,
+    // use a stack to keep track of directories to process.
+    while (processDirectories.length > 0) {
+        const { path: toProcess } = processDirectories.shift();
+        const {
+            directories,
+            files,
+            errors,
+            totalSize,
+            includeDirectory
+        } = await processDirectory(toProcess);
+
+        allErrors = allErrors.concat(errors);
+        if (includeDirectory) {
+            allDirectories = allDirectories.concat(directories);
+            allFiles = allFiles.concat(files);
+            walkedTotalSize += totalSize;
+
+            if (includeDescendents) {
+                processDirectories = processDirectories.concat(directories);
+            }
+
+            if (allDirectories.length + allFiles.length > maximumPaths) {
+                throw new UploadError(`Walked directory exceeded the maximum number of ${maximumPaths} paths`, ErrorCodes.TOO_LARGE);
+            }
+        } else {
+            removeFromArray(toProcess, allDirectories);
+        }
+    }
+
+    return {
+        directories: removeEmptyDirectories(allDirectories, allFiles),
+        files: allFiles,
+        errors: allErrors,
+        totalSize: walkedTotalSize
+    }
 }


### PR DESCRIPTION
## Description

This PR introduces functionality that will traverse a directory and all of its descendants, using the newly updated [`DirectBinaryUploadProcess`](https://github.com/adobe/aem-upload/pull/30) to upload the contents of each directory.

The strategy for maximizing the performance of recursively uploading directories will be as follows:

* Walk the entire directory structure of the path to be uploaded.
* As each directory is walked, build a list of all files in the directory.
* Build a list of all parts for all files in the directory.
* Add all the parts to a "concurrent queue" that will continually and concurrently upload parts, up to a maximum number being uploaded at once.

These changes add the ability to walk a directory structure.

## Related Issue

Please see #20 for corresponding feature request.

## Motivation and Context

There have been several requests for this feature. It simplifies the process of uploading complex directory structures to AEM by allowing users to upload a local directory, which will be mirrored in AEM.

## How Has This Been Tested?

This applies to all the PRs that I'll submit for this feature. There is an existing set of unit tests, all of which are passing. I also added new tests to verify the new functionality that is introduced. In addition, I've created end-to-end tests that I manually ran against a local AEM instance to ensure the process works as expected.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
