### PR TITLE
update compatibility for older node versions.

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build
       run: npm run build
     - name: Lint
-      if: ${{ matrix.node-version }} != '6.10.3'
+      if: ${{ matrix.node-version }} == '10.16'
       run: npm run lint
     - name: Run unit tests
       run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Build
       run: npm run build
     - name: Lint
-      if: ${{ matrix.node-version }} == '10.16'
+      if: ${{ matrix.node-version == '10.16' }}
       run: npm run lint
     - name: Run unit tests
       run: npm test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.16, 10.19, 12.16, 12.19]
+        node-version: [6.10.3, 8.2.1, 10.16, 10.19, 12.16, 12.19]
 
     steps:
     - uses: actions/checkout@v2
@@ -32,6 +32,9 @@ jobs:
       run: npm install
     - name: Build
       run: npm run build
+    - name: Lint
+      if: ${{ matrix.node-version }} != '6.10.3'
+      run: npm run lint
     - name: Run unit tests
       run: npm test
     - name: Report coverage

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "license": "Apache-2.0",
   "repository": "adobe/aem-upload",
   "scripts": {
-    "test": "npm run testOnly && npm run lint",
-    "testOnly": "./node_modules/.bin/mocha --recursive --require @babel/register ./test",
+    "test": "./node_modules/.bin/mocha --recursive --require @babel/register ./test",
     "build": "./node_modules/.bin/rimraf dist && ./node_modules/.bin/babel ./src --out-dir dist",
     "prepublishOnly": "npm test && npm run build",
     "coverage": "./node_modules/.bin/nyc npm run test",
@@ -29,7 +28,7 @@
     "core-js": "^3.6.4",
     "filesize": "^4.2.1",
     "regenerator-runtime": "^0.13.5",
-    "uuid": "^8.3.1"
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.8.4",

--- a/src/batch-manager.js
+++ b/src/batch-manager.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { v4 as uuid } from 'uuid';
+import uuid from 'uuid';
 
 import { getLock } from './utils';
 

--- a/src/exports.js
+++ b/src/exports.js
@@ -10,8 +10,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export { default as DirectBinaryUpload } from './direct-binary-upload';
-export { default as DirectBinaryUploadOptions } from './direct-binary-upload-options';
-export { default as DirectBinaryUploadErrorCodes } from './error-codes';
-export { default as FileSystemUpload } from './filesystem-upload';
-export { default as FileSystemUploadOptions } from './filesystem-upload-options';
+import DirectBinaryUpload from './direct-binary-upload';
+import DirectBinaryUploadOptions from './direct-binary-upload-options';
+import DirectBinaryUploadErrorCodes from './error-codes';
+import FileSystemUpload from './filesystem-upload';
+import FileSystemUploadOptions from './filesystem-upload-options';
+
+export default {
+    DirectBinaryUpload,
+    DirectBinaryUploadOptions,
+    DirectBinaryUploadErrorCodes,
+    FileSystemUpload,
+    FileSystemUploadOptions,
+}

--- a/src/filesystem-upload.js
+++ b/src/filesystem-upload.js
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { promises as fs } from 'fs';
+import fs from './fs-promise';
 import Path from 'path';
-import { v4 as uuid } from 'uuid';
+import uuid from 'uuid';
 
 import DirectBinaryUpload from './direct-binary-upload';
 import DirectBinaryUploadProcess from './direct-binary-upload-process';

--- a/src/fs-promise.js
+++ b/src/fs-promise.js
@@ -1,0 +1,58 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import fs from 'fs';
+import UploadError from './upload-error';
+import ErrorCodes from './error-codes';
+
+const unsupportedError = () => {
+    throw new UploadError('filesystem operations are not permitted in a browser', ErrorCodes.INVALID_OPTIONS);
+};
+
+let stat = unsupportedError;
+let readdir = unsupportedError;
+let createReadStream = unsupportedError;
+
+// fs module is not supported in browsers
+if (fs) {
+    // doing this manually and not using promisify to support older
+    // versions of node
+    stat = (path) => {
+        return new Promise((res, rej) => {
+            fs.stat(path, (err, stats) => {
+                if (err) {
+                    rej(err);
+                    return;
+                }
+                res(stats);
+            })
+        });
+    };
+    readdir = (path) => {
+        return new Promise((res, rej) => {
+            fs.readdir(path, (err, result) => {
+                if (err) {
+                    rej(err);
+                    return;
+                }
+                res(result);
+            })
+        });
+    };
+    createReadStream = fs.createReadStream;
+}
+
+export default {
+    stat,
+    readdir,
+    createReadStream,
+};

--- a/src/http/http-client.js
+++ b/src/http/http-client.js
@@ -15,7 +15,7 @@ import ErrorCodes from '../error-codes';
 import UploadOptionsBase from '../upload-options-base';
 import UploadError from '../upload-error';
 import HttpResponse from './http-response';
-import { v4 as uuid } from 'uuid';
+import uuid from 'uuid';
 
 /**
  * Invoked when there is an immediate retry error. Handles special cases and adds the

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { promises as fs } from 'fs';
+import fs from './fs-promise';
 import Async from 'async';
 import Path from 'path';
 import AsyncLock from 'async-lock';

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+import should from 'should';
+
+import { importFile } from './testutils';
+
+const Exports = importFile('exports');
+
+describe('Exports Tests', function() {
+
+    it('test exports smoke test', function() {
+        should(Exports).be.ok();
+        should(Exports.DirectBinaryUpload).be.ok();
+        should(Exports.DirectBinaryUploadOptions).be.ok();
+        should(Exports.FileSystemUpload).be.ok();
+        should(Exports.FileSystemUploadOptions).be.ok();
+        should(Exports.DirectBinaryUploadErrorCodes).be.ok();
+    });
+
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -27,20 +27,18 @@ const {
     trimContentDam,
     walkDirectory
 } = importFile('utils', {
-    'fs': {
-        promises: {
-            stat: async function(path) {
-                if (Path.basename(path) === 'error.jpg') {
-                    throw new Error('unit test stat error');
-                }
-                return stats[path];
-            },
-            readdir: async function(path) {
-                if (Path.basename(path) === 'error') {
-                    throw new Error('unit test readdir error');
-                }
-                return dirs[path];
+    './fs-promise': {
+        stat: async function(path) {
+            if (Path.basename(path) === 'error.jpg') {
+                throw new Error('unit test stat error');
             }
+            return stats[path];
+        },
+        readdir: async function(path) {
+            if (Path.basename(path) === 'error') {
+                throw new Error('unit test readdir error');
+            }
+            return dirs[path];
         }
     }
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The library needs to support some very old versions of Node.js. This PR adds those versions to the testing actions that run on commits. It also fixes some incompatibility issues with the older versions.

## Related Issue

N/A

## Motivation and Context

The library is used by AEM desktop, which (for reasons we won't get into here) must run on older versions of node.js. The library must support these older versions so that it can be used by the app.

## How Has This Been Tested?

Locally ran unit tests on the older versions of node.js.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
