### PR TITLE
add the ability to specify upload file information when doing file system uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -805,6 +805,25 @@ There is a set of options, `FileSystemUploadOptions`, that are specific to uploa
                 </code>
             </td>
         </tr>
+        <tr>
+            <td>Upload file options</td>
+            <td>object</td>
+            <td>
+                Specifies the options to use when uploading each file as part of the file system upload. Most of the options provided when using
+                `DirectBinaryUploadOptions.withUploadFiles()` are valid. The exceptions are `fileName`, `fileSize`, `filePath`, and `blob`, which
+                will be ignored.
+                <br/>
+                <br/>
+                <b>Example</b>
+                <br/>
+                <code>
+                options.withUploadFileOptions({<br/>
+                &nbsp;&nbsp;createVersion: true,<br/>
+                &nbsp;&nbsp;versionLabel: 'version-label'<br/>
+                });
+                </code>
+            </td>
+        </tr>
     </tbody>
 </table>
 

--- a/src/file-upload-result.js
+++ b/src/file-upload-result.js
@@ -290,6 +290,26 @@ export default class FileUploadResult extends HttpResult {
             data.cancelled = true;
         }
 
+        const createVersion = this.initResponseFileInfo.shouldCreateNewVersion();
+        const versionLabel = this.initResponseFileInfo.getVersionLabel();
+        const versionComment = this.initResponseFileInfo.getVersionComment();
+        const shouldReplace = this.initResponseFileInfo.shouldReplace();
+        if (createVersion) {
+            data.createVersion = createVersion;
+        }
+
+        if (versionLabel) {
+            data.versionLabel = versionLabel;
+        }
+
+        if (versionComment) {
+            data.versionComment = versionComment;
+        }
+
+        if (shouldReplace) {
+            data.replace = shouldReplace;
+        }
+
         return data;
     }
 }

--- a/src/filesystem-upload-options.js
+++ b/src/filesystem-upload-options.js
@@ -145,6 +145,21 @@ export default class FileSystemUploadOptions extends DirectBinaryUploadOptions {
     }
 
     /**
+     * Upload file options that will be applied to each file that is uploaded as
+     * part of the file system upload. Most options that can be passed as part of
+     * a single file upload using DirectBinaryUploadOptions.withUploadFiles() are
+     * valid. The only exceptions are "fileName", "fileSize", "filePath", and
+     * "blob", which will be ignored.
+     *
+     * @param {object} options Upload file options to apply to each file.
+     */
+    withUploadFileOptions(options) {
+        this.uploadFileOptions = options;
+        return this;
+    }
+
+
+    /**
      * Retrieves the maximum number of files that the module can upload in a single upload
      * request.
      *
@@ -189,6 +204,16 @@ export default class FileSystemUploadOptions extends DirectBinaryUploadOptions {
      */
     getInvalidCharacterReplaceValue() {
         return this.replaceValue;
+    }
+
+    /**
+     * Retrieves the upload file options that will be applied to each file uploaded
+     * through the module.
+     *
+     * @returns {object} Upload file options.
+     */
+    getUploadFileOptions() {
+        return this.uploadFileOptions || {};
     }
 
 }

--- a/src/filesystem-upload.js
+++ b/src/filesystem-upload.js
@@ -39,6 +39,7 @@ import {
     getMaxFileCount,
 } from './filesystem-upload-utils';
 import FileSystemUploadItemManager from './filesystem-upload-item-manager';
+import { file } from 'mock-fs/lib/filesystem';
 
 const MAX_CONCURRENT_DIRS = 10;
 
@@ -53,10 +54,20 @@ export default class FileSystemUpload extends DirectBinaryUpload {
      * @param {DirectBinaryUploadOptions} options Controls how the upload process behaves.
      * @param {Array} localPaths List of local paths to upload. If a path is a directory then its
      *  files will be retrieved and added to the upload.
-     * @returns {Promise} Will be resolved when all the files have been uploaded. The data
-     *  passed in successful resolution will be an instance of UploadResult.
-     */
-    async upload(options, localPaths) {
++     * @param {object} [fileOptions] If provided, contains additional options to apply to certain
++     *  files within the given list of paths. They keys for the object should be the full local path
++     *  to a file, and the value an object containing any combination of the following properties,
++     *  which will be applied to the file whose path matches the key:
++     *   * {boolean} createVersion: If true, the process will create a new version of the file if it
++     *      already exists.
++     *   * {string} versionLabel: The label to assign to the new version if one is created.
++     *   * {string} versionComment: Comment to assign to the new version if one is created.
++     *   * {boolean} replace: Will delete an asset if it already exists and replace it with the
++     *      new asset.
+      * @returns {Promise} Will be resolved when all the files have been uploaded. The data
+      *  passed in successful resolution will be an instance of UploadResult.
+      */
+      async upload(options, localPaths, fileOptions = {}) {
         const fileSystemUploadOptions = FileSystemUploadOptions.fromOptions(options);
         const uploadOptions = this.getOptions();
         const httpClient = new HttpClient(uploadOptions, fileSystemUploadOptions);
@@ -94,7 +105,7 @@ export default class FileSystemUpload extends DirectBinaryUpload {
         // in the number of directories to upload at a time.
         await concurrentLoop(directoriesWithFiles, MAX_CONCURRENT_DIRS, async (directoryUrl) => {
             const targetFiles = aggregatedFiles[directoryUrl];
-            const uploadFiles = this.convertToUploadFiles(targetFiles);
+            const uploadFiles = this.convertToUploadFiles(targetFiles, fileOptions);
 
             this.logInfo(`Uploading ${uploadFiles.length} files to directory ${directoryUrl}`);
 
@@ -133,13 +144,18 @@ export default class FileSystemUpload extends DirectBinaryUpload {
      * Converts a list of FileSystemUploadAsset instances to a list of UploadFile items, ready
      * for use in upload options.
      * @param {Array} files List of FileSystemUploadAsset instances.
+     * @param {object} fileOptions Additional options to apply to files whose paths match the
+     *  keys in the object.
      * @returns {Array} List of files ready for use with DirectBinaryUploadOptions.withUploadFiles().
      */
-    convertToUploadFiles(files) {
+    convertToUploadFiles(files, fileOptions) {
         const fileList = [];
 
         files.forEach(file => {
+            const addlOptions = fileOptions[file.getLocalPath()] || {};
+
             fileList.push({
+                ...addlOptions,
                 fileName: file.getRemoteNodeName(),
                 filePath: file.getLocalPath(),
                 fileSize: file.getSize()

--- a/src/filesystem-upload.js
+++ b/src/filesystem-upload.js
@@ -47,23 +47,21 @@ const MAX_CONCURRENT_DIRS = 10;
  * Uploads one or more files from the local file system to a target AEM instance using direct binary access.
  */
 export default class FileSystemUpload extends DirectBinaryUpload {
-    /**
-     * Retrieves information from the local file system for a list of files, creates a new directory in
-     * AEM, then uploads each of the local files to the new directory using direct binary access.
-     *
-     * @param {DirectBinaryUploadOptions} options Controls how the upload process behaves.
-     * @param {Array} localPaths List of local paths to upload. If a path is a directory then its
-     *  files will be retrieved and added to the upload.
-+     * @param {object} [fileOptions] If provided, contains additional options to apply to certain
-+     *  files within the given list of paths. They keys for the object should be the full local path
-+     *  to a file, and the value an object containing any combination of the following properties,
-+     *  which will be applied to the file whose path matches the key:
-+     *   * {boolean} createVersion: If true, the process will create a new version of the file if it
-+     *      already exists.
-+     *   * {string} versionLabel: The label to assign to the new version if one is created.
-+     *   * {string} versionComment: Comment to assign to the new version if one is created.
-+     *   * {boolean} replace: Will delete an asset if it already exists and replace it with the
-+     *      new asset.
+     /**
+      * Retrieves information from the local file system for a list of files, creates a new directory in
+      * AEM, then uploads each of the local files to the new directory using direct binary access.
+      *
+      * @param {DirectBinaryUploadOptions} options Controls how the upload process behaves.
+      * @param {Array} localPaths List of local paths to upload. If a path is a directory then its
+      *  files will be retrieved and added to the upload.
+      * @param {object} [fileOptions] If provided, contains additional options to apply to all files
+      *  that are uploaded. The following properties will be applied to each file uploaded:
+      *   * {boolean} createVersion: If true, the process will create a new version of the file if it
+      *      already exists.
+      *   * {string} versionLabel: The label to assign to the new version if one is created.
+      *   * {string} versionComment: Comment to assign to the new version if one is created.
+      *   * {boolean} replace: Will delete an asset if it already exists and replace it with the
+      *      new asset.
       * @returns {Promise} Will be resolved when all the files have been uploaded. The data
       *  passed in successful resolution will be an instance of UploadResult.
       */
@@ -152,10 +150,8 @@ export default class FileSystemUpload extends DirectBinaryUpload {
         const fileList = [];
 
         files.forEach(file => {
-            const addlOptions = fileOptions[file.getLocalPath()] || {};
-
             fileList.push({
-                ...addlOptions,
+                ...fileOptions,
                 fileName: file.getRemoteNodeName(),
                 filePath: file.getLocalPath(),
                 fileSize: file.getSize()

--- a/src/filesystem-upload.js
+++ b/src/filesystem-upload.js
@@ -46,17 +46,17 @@ const MAX_CONCURRENT_DIRS = 10;
  * Uploads one or more files from the local file system to a target AEM instance using direct binary access.
  */
 export default class FileSystemUpload extends DirectBinaryUpload {
-     /**
-      * Retrieves information from the local file system for a list of files, creates a new directory in
-      * AEM, then uploads each of the local files to the new directory using direct binary access.
-      *
-      * @param {DirectBinaryUploadOptions} options Controls how the upload process behaves.
-      * @param {Array} localPaths List of local paths to upload. If a path is a directory then its
-      *  files will be retrieved and added to the upload.
-      * @returns {Promise} Will be resolved when all the files have been uploaded. The data
-      *  passed in successful resolution will be an instance of UploadResult.
-      */
-      async upload(options, localPaths) {
+    /**
+     * Retrieves information from the local file system for a list of files, creates a new directory in
+     * AEM, then uploads each of the local files to the new directory using direct binary access.
+     *
+     * @param {DirectBinaryUploadOptions} options Controls how the upload process behaves.
+     * @param {Array} localPaths List of local paths to upload. If a path is a directory then its
+     *  files will be retrieved and added to the upload.
+     * @returns {Promise} Will be resolved when all the files have been uploaded. The data
+     *  passed in successful resolution will be an instance of UploadResult.
+     */
+    async upload(options, localPaths) {
         const fileSystemUploadOptions = FileSystemUploadOptions.fromOptions(options);
         const uploadOptions = this.getOptions();
         const httpClient = new HttpClient(uploadOptions, fileSystemUploadOptions);

--- a/src/filesystem-upload.js
+++ b/src/filesystem-upload.js
@@ -39,7 +39,6 @@ import {
     getMaxFileCount,
 } from './filesystem-upload-utils';
 import FileSystemUploadItemManager from './filesystem-upload-item-manager';
-import { file } from 'mock-fs/lib/filesystem';
 
 const MAX_CONCURRENT_DIRS = 10;
 

--- a/test/filesystem-upload-options.test.js
+++ b/test/filesystem-upload-options.test.js
@@ -22,6 +22,13 @@ describe('FileSystemUploadOptions Tests', function() {
         options = new FileSystemUploadOptions();
     });
 
+    it('test accessors', function() {
+        should(options.getUploadFileOptions()).be.ok();
+        const newOptions = options.withUploadFileOptions({ hello: 'world!' });
+        should(newOptions).be.ok();
+        should(options.getUploadFileOptions().hello).be.exactly('world!');
+    });
+
     it('test from options', async function() {
         let options = new FileSystemUploadOptions()
             .withMaxUploadFiles(20)

--- a/test/filesystem-upload.test.js
+++ b/test/filesystem-upload.test.js
@@ -100,7 +100,14 @@ describe('FileSystemUpload Tests', () => {
                 `/test/file/${ASSET1}`,
                 '/test/file/2',
                 '/test/dir',
-            ]);
+            ], {
+                '/test/file/2': {
+                    createVersion: true,
+                    versionLabel: 'test version label',
+                    versionComment: 'test version comment',
+                    replace: true
+                }
+            });
 
             should(result).be.ok();
             should(result.getErrors().length).be.exactly(0);
@@ -117,6 +124,12 @@ describe('FileSystemUpload Tests', () => {
             validateUploadFile(fileLookup['2'], 10);
             validateUploadFile(fileLookup['3'], 8);
             validateUploadFile(fileLookup['4'], 7);
+
+            const addlOptions = fileLookup['2'].toJSON();
+            should(addlOptions.createVersion).be.ok();
+            should(addlOptions.versionLabel).be.exactly('test version label');
+            should(addlOptions.versionComment).be.exactly('test version comment');
+            should(addlOptions.replace).be.ok();
         });
 
         it('test directory already exists', async () => {

--- a/test/filesystem-upload.test.js
+++ b/test/filesystem-upload.test.js
@@ -101,12 +101,10 @@ describe('FileSystemUpload Tests', () => {
                 '/test/file/2',
                 '/test/dir',
             ], {
-                '/test/file/2': {
-                    createVersion: true,
-                    versionLabel: 'test version label',
-                    versionComment: 'test version comment',
-                    replace: true
-                }
+                createVersion: true,
+                versionLabel: 'test version label',
+                versionComment: 'test version comment',
+                replace: true
             });
 
             should(result).be.ok();

--- a/test/filesystem-upload.test.js
+++ b/test/filesystem-upload.test.js
@@ -93,19 +93,20 @@ describe('FileSystemUpload Tests', () => {
 
             const uploadOptions = new FileSystemUploadOptions()
                 .withUrl(MockRequest.getUrl('/target'))
-                .withBasicAuth('testauth');
+                .withBasicAuth('testauth')
+                .withUploadFileOptions({
+                    createVersion: true,
+                    versionLabel: 'test version label',
+                    versionComment: 'test version comment',
+                    replace: true
+                });
 
             const fileSystemUpload = new FileSystemUpload(getTestOptions());
             const result = await fileSystemUpload.upload(uploadOptions, [
                 `/test/file/${ASSET1}`,
                 '/test/file/2',
                 '/test/dir',
-            ], {
-                createVersion: true,
-                versionLabel: 'test version label',
-                versionComment: 'test version comment',
-                replace: true
-            });
+            ]);
 
             should(result).be.ok();
             should(result.getErrors().length).be.exactly(0);


### PR DESCRIPTION
## Description

See #40 for a description of the requested feature.

This PR provides an implementation by allowing an additional parameter on `FileSystemUpload.upload()`. This new parameter contains a simple object, whose properties can match any of the properties defined for an upload file (i.e. `createVersion`, `versionComment`, etc). These properties will be applied to each file that is uploaded.

## Related Issue

#40 

## Motivation and Context

The tool currently doesn't provide a way to specify how conflicts are handled. Some consumers may wish for a certain behavior when uploading the same asset more than once.

## How Has This Been Tested?

Added new unit tests, and verified that the options are honored when multiple files are uploaded. Verified that versions are created and that they have the appropriate values.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
