### PR TITLE
update to latest version of http transfer to improve retry functionality

### DIFF
--- a/e2e/filesystem-upload.test.js
+++ b/e2e/filesystem-upload.test.js
@@ -197,7 +197,7 @@ describe('FileSystemUpload end-to-end tests', function() {
 
         monitorEvents(fileSystemUpload);
 
-        const uploadResult = await fileSystemUpload.upload(uploadOptions, [
+        await fileSystemUpload.upload(uploadOptions, [
             Path.join(__dirname, 'edge-case-images/zero-byte.jpg'),
         ]);
         should(events.length).be.exactly(1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@adobe/httptransfer": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@adobe/httptransfer/-/httptransfer-2.6.0.tgz",
-      "integrity": "sha512-Isk/pi4139bo8MYHptYfmZRtc70s0u+7VJ+4SUdJS3eaL9p95mglEzw0JdK+S81cRYELHMnJK7EpOd/LGjchWg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@adobe/httptransfer/-/httptransfer-2.7.0.tgz",
+      "integrity": "sha512-O5XxPVJDXMD/kt8LhqH71I5QB/+xc9vV63KivvcfNtXJhAZ6yW7i7++aeBEnCcIhxkuiXOobhaqrQZK+2mZopg==",
       "requires": {
         "@babel/runtime": "^7.14.0",
         "content-disposition": "^0.5.3",
@@ -31,9 +31,9 @@
           }
         },
         "core-js": {
-          "version": "3.11.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.11.3.tgz",
-          "integrity": "sha512-DFEW9BllWw781Op5KdYGtXfj3s9Cmykzt16bY6elaVuqXHCUwF/5pv0H3IJ7/I3BGjK7OeU+GrjD1ChCkBJPuA=="
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.14.0.tgz",
+          "integrity": "sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA=="
         },
         "debug": {
           "version": "4.3.1",
@@ -3066,9 +3066,9 @@
       },
       "dependencies": {
         "iconv-lite": {
-          "version": "0.6.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
-          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "bugs": "https://github.com/adobe/aem-upload",
   "dependencies": {
-    "@adobe/httptransfer": "^2.6.0",
+    "@adobe/httptransfer": "^2.7.0",
     "async": "^3.2.0",
     "async-lock": "^1.2.8",
     "axios": "^0.21.1",


### PR DESCRIPTION
## Description

Updates to the latest version of httptransfer, which improves cases where an HTTP retry is required.

## Related Issue

## Motivation and Context

To improve the stability of very large file uploads.

## How Has This Been Tested?

Manual testing, unit tests pass, e2e tests pass.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- ~[ ] My change requires a change to the documentation.~
- ~[ ] I have updated the documentation accordingly.~
- [x] I have read the **CONTRIBUTING** document.
- ~[ ] I have added tests to cover my changes.~
- [x] All new and existing tests passed.
