### PR TITLE
Fix mime-type handling in AEM uploads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@adobe/aem-upload",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@adobe/httptransfer": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@adobe/httptransfer/-/httptransfer-2.7.0.tgz",
-      "integrity": "sha512-O5XxPVJDXMD/kt8LhqH71I5QB/+xc9vV63KivvcfNtXJhAZ6yW7i7++aeBEnCcIhxkuiXOobhaqrQZK+2mZopg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@adobe/httptransfer/-/httptransfer-2.7.1.tgz",
+      "integrity": "sha512-GOtNwJ0wzgsZknbdhgFrk7brXzB2RfFwoE4VHEhDNR2ceEyYnLGurXe4IDZAgWU6lFaaN917fzyGhYNMep5kjg==",
       "requires": {
         "@babel/runtime": "^7.14.0",
         "content-disposition": "^0.5.3",
@@ -23,22 +23,22 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.0.tgz",
-          "integrity": "sha512-JELkvo/DlpNdJ7dlyw/eY7E0suy5i5GQH+Vlxaq1nsNJ+H7f4Vtv3jMeCEgRhZZQFXTjldYfQgv2qmM6M1v5wA==",
+          "version": "7.14.8",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
+          "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "core-js": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.14.0.tgz",
-          "integrity": "sha512-3s+ed8er9ahK+zJpp9ZtuVcDoFzHNiZsPbNAAE4KXgrRHbjSqqNN6xGSXq6bq7TZIbKj4NLrLb6bJ5i+vSVjHA=="
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
+          "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q=="
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "requires": {
             "ms": "2.1.2"
           }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "bugs": "https://github.com/adobe/aem-upload",
   "dependencies": {
-    "@adobe/httptransfer": "^2.7.0",
+    "@adobe/httptransfer": "^2.7.1",
     "async": "^3.2.0",
     "async-lock": "^1.2.8",
     "axios": "^0.21.1",


### PR DESCRIPTION
## Description

The fix is in `@adobe/node-httptransfer`: https://github.com/adobe/node-httptransfer/pull/64
This PR pulls in the dependency update.

## How Has This Been Tested?

The PR has been tested manually, and through unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
