### PR TITLE
correct characters that are sanitized in folder names

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -55,7 +55,7 @@ export const RegularExpressions = {
      * Will match values that contain characters that are invalid in AEM folder node
      * names.
      */
-    INVALID_FOLDER_CHARACTERS_REGEX: /[%;#,+?^{}\s"]/g,
+    INVALID_FOLDER_CHARACTERS_REGEX: /[%;#+?^{}\s"&]/g,
 
     /**
      * Will match values that contain characters that are invalid in AEM asset node


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed the set of characters that are sanitized in a folder's name when uploading from local.

## Related Issue

#56 

## Motivation and Context

The behavior of the library is inconsistent with AEM' requirements.

## How Has This Been Tested?

Ran a test upload to ensure sanitization is correct. All unit tests pass.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
