### PR TITLE
Add ability to specify headers to include in part uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,14 +179,28 @@ The `DirectBinaryUploadOptions` class supports the following options. Items with
                         </tr>
                         <tr>
                             <td>blob</td>
-                            <td>Array-like</td>
+                            <td>File</td>
                             <td>
-                                Value containing the data for a file. This can potentially be multiple
-                                types of values, as long as the value supports the <code>slice()</code> method (like
-                                an array). Note that either this value <i>or</i> <code>filePath</code>
+                                Data for a file. The only tested and supported value for this property is the <code>value</code> of an HTML <code>&lt;input type='file' /></code>.
+                                Note that either this property <i>or</i> <code>filePath</code>
                                 must be specified. This option is typically most useful when running the
-                                upload tool from a browser; the <code>value</code> of a <code>&lt;input type='file' /></code>
-                                can be used as the <code>blob</code> value.
+                                upload tool from a browser.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>partHeaders</td>
+                            <td>object</td>
+                            <td>
+                                Header values to be included with each part of this file that is transferred. The headers from `DirectBinaryUploadOptions` are
+                                only included in requests that are sent to the target instance; they are ignored when sending requests to the direct binary upload URIs
+                                provided by the instance. This option provides a means for specifying any additional headers that should be included in requests sent to
+                                these URIs.
+                                <br/>
+                                <br/>
+                                Default: <code>{}</code>
+                                <br/>
+                                <br/>
+                                Example: <code>{ 'user-agent': 'My User Agent' }</code>
                             </td>
                         </tr>
                         <tr>
@@ -255,9 +269,11 @@ options.withUploadFiles([
     {
         fileName: 'file2.jpg',
         fileSize: 2048,
-        blob: [
-            'h', 'e', 'l', 'l', 'o'
-        ]
+        // note that this assumes HTML similar to:
+        // &lt;form name="formName">
+        //   &lt;input type="file" name="fileInputName" />
+        // &lt;/form>
+        blob: document.forms['formName']['fileInputName'].files[0]
     }
 ]);</pre>
             </td>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@adobe/httptransfer": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@adobe/httptransfer/-/httptransfer-2.7.1.tgz",
-      "integrity": "sha512-GOtNwJ0wzgsZknbdhgFrk7brXzB2RfFwoE4VHEhDNR2ceEyYnLGurXe4IDZAgWU6lFaaN917fzyGhYNMep5kjg==",
+      "version": "2.8.1",
+      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-platform-release/@adobe/httptransfer/-/httptransfer-2.8.1.tgz",
+      "integrity": "sha1-GXBtczlkQMznf/XIlO+/sR3oGIw=",
       "requires": {
         "@babel/runtime": "^7.14.0",
         "content-disposition": "^0.5.3",
@@ -23,17 +23,17 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.14.8",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.8.tgz",
-          "integrity": "sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==",
+          "version": "7.16.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
+          "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "core-js": {
-          "version": "3.15.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
-          "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q=="
+          "version": "3.19.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.1.tgz",
+          "integrity": "sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg=="
         },
         "debug": {
           "version": "4.3.2",
@@ -2940,9 +2940,9 @@
       }
     },
     "content-range": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-range/-/content-range-2.0.0.tgz",
-      "integrity": "sha512-zTebzPhul1gn8C7DrYi0PtjhhnbAMTHDOBB8UmBmKgmd6YJ9wNYUOlAn5iq/X0TUCNzsstm+jhihYKARdy1wjg=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/content-range/-/content-range-2.0.2.tgz",
+      "integrity": "sha512-ayHd/VQMRfWFBLVXyYvNhbbR+vq5OgLJnViGV4arzQiX9odRhf1spmXF7pFEHiR8htli29Hbii0URCNfUTN4vQ=="
     },
     "content-type": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "bugs": "https://github.com/adobe/aem-upload",
   "dependencies": {
-    "@adobe/httptransfer": "^2.7.1",
+    "@adobe/httptransfer": "^2.8.1",
     "async": "^3.2.0",
     "async-lock": "^1.2.8",
     "axios": "^0.21.1",

--- a/src/direct-binary-upload-options.js
+++ b/src/direct-binary-upload-options.js
@@ -72,7 +72,7 @@ class DirectBinaryUploadOptions {
 
     /**
      * If specified, an object containing headers that will be sent along with each
-     * request submitted to the target.
+     * request submitted to the target instance.
      *
      * The given headers will be merged with any headers specified previously using
      * the method.
@@ -269,11 +269,12 @@ class DirectBinaryUploadOptions {
      * @returns {Array} List of UploadFile instances as provided to the options instance.
      */
     getUploadFiles() {
-        return this.options.uploadFiles;
+        return this.options.uploadFiles || [];
     }
 
     /**
-     * Retrieves the headers that will be added to each request sent to the target.
+     * Retrieves the headers that will be added to each request sent to the target
+     * instance.
      *
      * @returns {object} The headers as provided to the options instance.
      */

--- a/src/direct-binary-upload-process.js
+++ b/src/direct-binary-upload-process.js
@@ -123,7 +123,7 @@ export default class DirectBinaryUploadProcess extends FileTransferHandler {
 
         uploadResult.startTimer();
 
-        this.logInfo(`sending ${fileCount} files to httptransfer`);
+        this.logInfo(`sending ${fileCount} files to httptransfer with options ${JSON.stringify(aemUploadOptions, null, 2)}`);
         uploadResult.addTotalFiles(fileCount);
         await aemUpload.uploadFiles(aemUploadOptions);
         this.logInfo('successfully uploaded files with httptransfer');

--- a/src/upload-file.js
+++ b/src/upload-file.js
@@ -160,6 +160,17 @@ export default class UploadFile extends UploadOptionsBase {
     }
 
     /**
+     * Retrieves the headers that should be included with each part upload request.
+     * @returns {object} Simple object whose names are header names, and whose values
+     *  are header values.
+     */
+    getPartHeaders() {
+        ensureRequiredOptions(this.fileOptions);
+        const { partHeaders = {} } = this.fileOptions;
+        return partHeaders;
+    }
+
+    /**
      * Converts the class instance into a simple object representation.
      *
      * @returns {object} Simplified view of the class instance.
@@ -192,6 +203,9 @@ export default class UploadFile extends UploadOptionsBase {
 
         if (filePath) {
             json.filePath = filePath;
+        }
+        if (Object.keys(this.getPartHeaders()).length) {
+            json.multipartHeaders = this.getPartHeaders();
         }
         return json;
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -444,7 +444,12 @@ export function getHttpTransferOptions(options, directBinaryUploadOptions) {
     // single url and individual file names to the fileUrl format.
     const convertedFiles = directBinaryUploadOptions.getUploadFiles().map((uploadFile) => {
         const uploadFileInstance = new UploadFile(options, directBinaryUploadOptions, uploadFile);
-        return uploadFileInstance.toJSON();
+        const transferOptions = uploadFileInstance.toJSON();
+        if (uploadFile.blob) {
+            // ensure blob is passed through to transfer options
+            transferOptions.blob = uploadFile.blob;
+        }
+        return transferOptions;
     });
 
     return {

--- a/test/upload-file.test.js
+++ b/test/upload-file.test.js
@@ -64,4 +64,29 @@ describe('UploadFile Tests', function() {
             blob: {}
         });
     });
+
+    it('test part headers', function() {
+        const uploadOptions = new DirectBinaryUploadOptions()
+            .withUrl('http://somefakeunittesturl');
+        let uploadFile = new UploadFile(getTestOptions(), uploadOptions, {
+            fileName: 'testfile.jpg',
+            fileSize: 1024,
+            filePath: '/test/file.jpg'
+        });
+        should(uploadFile.getPartHeaders()).be.ok();
+        should(uploadFile.getPartHeaders().missing).not.be.ok();
+        should(uploadFile.toJSON().multipartHeaders).not.be.ok();
+
+        uploadFile = new UploadFile(getTestOptions(), uploadOptions, {
+            fileName: 'testfile.jpg',
+            fileSize: 1024,
+            filePath: '/test/file.jpg',
+            partHeaders: {
+                hello: 'world!'
+            }
+        });
+        should(uploadFile.getPartHeaders()).be.ok();
+        should(uploadFile.getPartHeaders().hello).equal('world!');
+        should(uploadFile.toJSON().multipartHeaders.hello).equal('world!');
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR introduces a new feature that allows consumers to specify which headers should be included in requests that upload individual file parts. These are typically the requests that are sent to a data store like Azure.

In addition, this PR resolves a small issue with blobs as described in #55.

## Related Issue

See #55 

## Motivation and Context

For the resolution to #55, it means that the library can once again be used in the context of a browser.

For the part headers, there may be cases where a data store like Azure (or a CDN in between) rejects requests that don't include certain header information (such as a User Agent). This new option provides consumers with the ability to provide additional headers to these requests; this was not possible before.

## How Has This Been Tested?

Unit test run locally. Manual testing from a React application show that browser uploads work. e2e tests pass when run locally.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
