### PR TITLE
update node-httptransfer to allow parens in asset names.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@adobe/httptransfer": {
-      "version": "2.8.1",
-      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-platform-release/@adobe/httptransfer/-/httptransfer-2.8.1.tgz",
-      "integrity": "sha1-GXBtczlkQMznf/XIlO+/sR3oGIw=",
+      "version": "2.8.2",
+      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-platform-release/@adobe/httptransfer/-/httptransfer-2.8.2.tgz",
+      "integrity": "sha1-h22Ga4nrGyZ1vzpgQvG4RAvwmTA=",
       "requires": {
         "@babel/runtime": "^7.14.0",
         "content-disposition": "^0.5.3",
@@ -23,25 +23,17 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.0.tgz",
-          "integrity": "sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==",
+          "version": "7.16.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz",
+          "integrity": "sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "core-js": {
-          "version": "3.19.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.1.tgz",
-          "integrity": "sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg=="
-        },
-        "debug": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-          "requires": {
-            "ms": "2.1.2"
-          }
+          "version": "3.19.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.3.tgz",
+          "integrity": "sha512-LeLBMgEGSsG7giquSzvgBrTS7V5UL6ks3eQlUSbN8dJStlLFiRzUm5iqsRyzUB8carhfKjkJ2vzKqE6z1Vga9g=="
         }
       }
     },
@@ -2842,7 +2834,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
       "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
       "requires": {
         "ms": "2.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "bugs": "https://github.com/adobe/aem-upload",
   "dependencies": {
-    "@adobe/httptransfer": "^2.8.1",
+    "@adobe/httptransfer": "^2.8.2",
     "async": "^3.2.0",
     "async-lock": "^1.2.8",
     "axios": "^0.21.4",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates to latest version of `node-httptransfer` to resolve issue where files with parens in the name fail to upload.

## Related Issue

#65 

## Motivation and Context

Parens are valid characters and should not be rejected.

## How Has This Been Tested?

* Manually tested
* Unit tests pass
* e2e tests pass

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
