### PR TITLE
fix issues when target URL contains encoded characters.

### DIFF
--- a/e2e/e2eutils.js
+++ b/e2e/e2eutils.js
@@ -139,3 +139,23 @@ module.exports.deleteAemPath = async function(httpClient, uploadOptions, relativ
 
     return httpClient.submit(request);
 }
+
+module.exports.createAemFolder = async function(httpClient, uploadOptions, folderName) {
+    const createUrl = `${uploadOptions.getUrl().replace('/content/dam', `/api/assets/${encodeURIComponent(folderName)}`)}`;
+
+    const data = JSON.stringify({
+        class: 'assetFolder',
+        properties: {
+            title: 'Test Folder'
+        }
+    });
+    const request = new HttpRequest(getTestOptions(), createUrl)
+        .withUploadOptions(uploadOptions)
+        .withMethod(HttpRequest.Method.POST)
+        .withHeaders({
+            'content-type': 'application/json',
+        })
+        .withData(data, data.length);
+
+    return httpClient.submit(request);
+}

--- a/src/direct-binary-upload-options.js
+++ b/src/direct-binary-upload-options.js
@@ -247,7 +247,7 @@ class DirectBinaryUploadOptions {
      */
     getTargetFolderPath() {
         const { pathname } = URL.parse(this.getUrl());
-        return decodeURI(pathname);
+        return decodeURIComponent(pathname);
     }
 
     /**

--- a/src/direct-binary-upload-options.js
+++ b/src/direct-binary-upload-options.js
@@ -241,11 +241,13 @@ class DirectBinaryUploadOptions {
      * Retrieves the path to the folder where the files will be uploaded. This value
      * is based on the URL that was provided to the options.
      *
+     * The path value will not be URL encoded.
+     *
      * @returns {string} Full path to a folder on the target.
      */
     getTargetFolderPath() {
         const { pathname } = URL.parse(this.getUrl());
-        return pathname;
+        return decodeURI(pathname);
     }
 
     /**

--- a/src/filesystem-upload-directory.js
+++ b/src/filesystem-upload-directory.js
@@ -50,6 +50,9 @@ export default class FileSystemUploadDirectory {
     /**
      * Retrieves the full, remote path (only) of the item. Will be built
      * using the remote node name provided in the constructor.
+     *
+     * The value will not be URL encoded.
+     *
      * @returns {string} Path ready for use in a URL.
      */
     getRemotePath() {

--- a/src/init-response-file-info.js
+++ b/src/init-response-file-info.js
@@ -52,6 +52,8 @@ export default class InitResponseFileInfo extends UploadOptionsBase {
     /**
      * Retrieves the full path to the location where the file will be uploaded in the target instance.
      *
+     * This value will not be URL encoded.
+     *
      * @returns {string} Full path to the file.
      */
     getTargetFilePath() {
@@ -168,7 +170,7 @@ export default class InitResponseFileInfo extends UploadOptionsBase {
      * @returns {object} Event information for the file.
      */
     getFileEventData() {
-        const targetFolder = decodeURI(this.getUploadOptions().getTargetFolderPath());
+        const targetFolder = this.getUploadOptions().getTargetFolderPath();
         return {
             fileName: this.getFileName(),
             fileSize: this.getFileSize(),

--- a/test/direct-binary-upload-options.test.js
+++ b/test/direct-binary-upload-options.test.js
@@ -47,4 +47,11 @@ describe('DirectBinaryUploadOptionsTest', () => {
             .withAddContentLengthHeader(true);
         should(options).be.ok();
     });
+
+    it('test getTargetFolderPath', () => {
+        const options = new DirectBinaryUploadOptions()
+            .withUrl('http://somereallyfakeurlhopefully/content/dam/test%20path/asset.jpg');
+        should(options.getTargetFolderPath()).be.exactly('/content/dam/test path/asset.jpg');
+    });
+
 });

--- a/test/filesystem-upload-directory.test.js
+++ b/test/filesystem-upload-directory.test.js
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const should = require('should');
+
+const { importFile } = require('./testutils');
+
+const FileSystemUploadDirectory = importFile('filesystem-upload-directory');
+const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
+
+describe('FileSystemUploadDirectory Tests', function() {
+    it('test get remote path', function() {
+        const options = new DirectBinaryUploadOptions()
+            .withUrl('http://somereallyfakeunittesturl/content/dam/test%20path');
+        const directory = new FileSystemUploadDirectory(options, '/local/directory', 'remote-name');
+        should(directory.getRemotePath()).be.exactly('/content/dam/test path/remote-name');
+
+        const child = new FileSystemUploadDirectory(options, '/local/directory/child', 'child-name', directory);
+        should(child.getRemotePath()).be.exactly('/content/dam/test path/remote-name/child-name');
+    });
+});

--- a/test/init-response-file-info.test.js
+++ b/test/init-response-file-info.test.js
@@ -22,7 +22,7 @@ describe('InitResponseFileInfo Tests', function() {
     it('test get target file path', function() {
         const options = {};
         const uploadOptions = new DirectBinaryUploadOptions()
-            .withUrl('http://somereallyfakeunittesturl/content/dam/test%20path');
+            .withUrl('http://somereallyfakeunittesturl/content/dam/test%2Bpath');
         const rawFileData = {
             fileName: 'asset.jpg',
             fileSize: 1024,
@@ -30,6 +30,10 @@ describe('InitResponseFileInfo Tests', function() {
         };
         const uploadFile = new UploadFile(options, uploadOptions, rawFileData);
         const fileInfo = new InitResponseFileInfo(options, uploadOptions, uploadFile, rawFileData);
-        should(fileInfo.getTargetFilePath()).be.exactly('/content/dam/test path/asset.jpg');
+        should(fileInfo.getTargetFilePath()).be.exactly('/content/dam/test+path/asset.jpg');
+
+        const eventData = fileInfo.getFileEventData();
+        should(eventData.targetFolder).be.exactly('/content/dam/test+path');
+        should(eventData.targetFile).be.exactly('/content/dam/test+path/asset.jpg');
     });
 });

--- a/test/init-response-file-info.test.js
+++ b/test/init-response-file-info.test.js
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 Adobe. All rights reserved.
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License. You may obtain a copy
+of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+OF ANY KIND, either express or implied. See the License for the specific language
+governing permissions and limitations under the License.
+*/
+
+const should = require('should');
+
+const { importFile } = require('./testutils');
+
+const InitResponseFileInfo = importFile('init-response-file-info');
+const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
+const UploadFile = importFile('upload-file');
+
+describe('InitResponseFileInfo Tests', function() {
+    it('test get target file path', function() {
+        const options = {};
+        const uploadOptions = new DirectBinaryUploadOptions()
+            .withUrl('http://somereallyfakeunittesturl/content/dam/test%20path');
+        const rawFileData = {
+            fileName: 'asset.jpg',
+            fileSize: 1024,
+            filePath: '/local/test/asset.jpg',
+        };
+        const uploadFile = new UploadFile(options, uploadOptions, rawFileData);
+        const fileInfo = new InitResponseFileInfo(options, uploadOptions, uploadFile, rawFileData);
+        should(fileInfo.getTargetFilePath()).be.exactly('/content/dam/test path/asset.jpg');
+    });
+});


### PR DESCRIPTION
## Description

There was an issue reported in AEM Desktop where the app would hang when trying to upload files or folders to a directory like `test中文`. Root cause of the issue was that the URL given to `aem-upload` was not URI encoded. However, upon properly encoding the URL, I identified problems within `aem-upload` itself. It's not handling encoding on incoming URLs as it should. There are more details in the related issue.

The fix itself was small - most of the changes in this PR are new unit tests and a new e2e test for verifying this case.

## Related Issue

#72 

## Motivation and Context

See related issue, but files/folders could not be uploaded to directories with characters requiring encoding.

## How Has This Been Tested?

* Manually linked the updated library to AEM Desktop locally, and verified that the issue was resolved. Also manually tested other common encoding issues seen in the app, and all cases passed.
* Added new unit tests for verifying this case.
* New e2e test that creates a directory on AEM with the problematic characters, then uploads files to it.
* All existing unit tests and e2e tests pass.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
