### PR TITLE
Fix: include uploadDuration when uploading files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,6 +884,9 @@ that the commit message of the PR begins with one of the following values:
 
 PRs whose messages do not meet this format will _not_ generate a new release.
 
+Release notes are generated based on semantic-release's [eslint](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint) preset. Follow the guidelines
+in the preset's documentation to include commit messages in a release's notes.
+
 # Todo
 * Pause/resume uploads
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,41 +5,41 @@
   "requires": true,
   "dependencies": {
     "@adobe/httptransfer": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@adobe/httptransfer/-/httptransfer-3.1.2.tgz",
-      "integrity": "sha512-Ki5BLV7nLh7TDpC16snVkkBLhoKIFqaHJFOcfIWOjU9KouS6tlbjim82QtnIQD0qFLEVyhe8a94W+mDNF3X47Q==",
+      "version": "3.2.1",
+      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-platform-release/@adobe/httptransfer/-/httptransfer-3.2.1.tgz",
+      "integrity": "sha512-P6Z1Hr3s/vnVfOx5CF4NQJmK7qKnO1P+QLQy1GdtxY3IBGrlmYXN/wplY2LxeY/tutd9UKw7ogdnO36skGE5AQ==",
       "requires": {
         "@babel/runtime": "^7.16.7",
         "content-disposition": "^0.5.4",
         "content-range": "^2.0.2",
         "content-type": "^1.0.4",
-        "core-js": "^3.20.2",
-        "debug": "^4.3.3",
+        "core-js": "^3.21.1",
+        "debug": "^4.3.4",
         "drange": "^2.0.1",
         "file-url": "2.0.2",
         "filter-obj": "^2.0.2",
-        "mime-types": "^2.1.34",
+        "mime-types": "^2.1.35",
         "node-fetch-npm": "^2.0.4",
         "valid-url": "^1.0.9"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.16.7",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.7.tgz",
-          "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
+          "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
         },
         "core-js": {
-          "version": "3.20.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
-          "integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw=="
+          "version": "3.22.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.7.tgz",
+          "integrity": "sha512-Jt8SReuDKVNZnZEzyEQT5eK6T2RRCXkfTq7Lo09kpm+fHjgGewSbNjV+Wt4yZMhPDdzz2x1ulI5z/w4nxpBseg=="
         },
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "requires": {
             "ms": "2.1.2"
           }
@@ -4113,7 +4113,7 @@
     "file-url": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/file-url/-/file-url-2.0.2.tgz",
-      "integrity": "sha1-6VF4TXkJUSfTcTApqwY/QIGMoq4="
+      "integrity": "sha512-x3989K8a1jM6vulMigE8VngH7C5nci0Ks5d9kVjUXmNF28gmiZUNujk5HjwaS8dAzN2QmUfX56riJKgN00dNRw=="
     },
     "filesize": {
       "version": "4.2.1",
@@ -5677,16 +5677,16 @@
       "integrity": "sha1-vXuRE1/GsBzePpuuM9ZZtj2IV+U="
     },
     "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
     },
     "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "requires": {
-        "mime-db": "1.51.0"
+        "mime-db": "1.52.0"
       }
     },
     "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "bugs": "https://github.com/adobe/aem-upload",
   "dependencies": {
-    "@adobe/httptransfer": "^3.1.2",
+    "@adobe/httptransfer": "^3.2.1",
     "async": "^3.2.0",
     "async-lock": "^1.2.8",
     "axios": "^0.21.4",


### PR DESCRIPTION
## Description

Updates to the latest version of `node-httptransfer` so that the `uploadDuration` property is provided in finalize calls.

## Related Issue

See related [node-httptransfer issue](https://github.com/adobe/node-httptransfer/issues/116) for details.

## Motivation and Context

Allows calculation of transfer rates on AEM's end.

## How Has This Been Tested?

All unit tests and e2e tests pass. Verified that parameter value is provided in AEM logs.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
