### PR TITLE
Fix: allow dots in file names.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -49,13 +49,13 @@ export const RegularExpressions = {
      * Will match values that contain characters that are invalid in AEM node
      * names.
      */
-    INVALID_CHARACTERS_REGEX: /[./:[\]|*\\]/g,
+    INVALID_CHARACTERS_REGEX: /[/:[\]|*\\]/g,
 
     /**
      * Will match values that contain characters that are invalid in AEM folder node
      * names.
      */
-    INVALID_FOLDER_CHARACTERS_REGEX: /[%;#+?^{}\s"&]/g,
+    INVALID_FOLDER_CHARACTERS_REGEX: /[.%;#+?^{}\s"&]/g,
 
     /**
      * Will match values that contain characters that are invalid in AEM asset node

--- a/test/filesystem-upload-utils.test.js
+++ b/test/filesystem-upload-utils.test.js
@@ -24,14 +24,14 @@ describe('FileSystemUploadUtils Tests', function() {
     });
 
     it('test clean folder name', async function () {
-        should(await cleanFolderName(options, 'A b:c')).be.exactly('a-b-c');
+        should(await cleanFolderName(options, 'A b:c.d')).be.exactly('a-b-c-d');
         options.withFolderNodeNameProcessor(async (folderName) => folderName)
             .withInvalidCharacterReplaceValue('_');
         should(await cleanFolderName(options, 'A b:c')).be.exactly('A b_c');
     });
 
     it('test clean asset name', async function () {
-        should(await cleanAssetName(options, 'A #b:c.jpg')).be.exactly('A -b-c.jpg');
+        should(await cleanAssetName(options, 'A #b:c.d.jpg')).be.exactly('A -b-c.d.jpg');
         options.withAssetNodeNameProcessor(async (assetName) => assetName)
             .withInvalidCharacterReplaceValue('_');
         should(await cleanAssetName(options, 'A #b:c')).be.exactly('A #b_c');


### PR DESCRIPTION
## Description

Modifies the set of illegal characters so that periods are allowed in file names.

## Related Issue

#79 

## Motivation and Context

Some consumers of the module use dots in file names as part of their naming conventions. This brings the library's functionality inline with AEM's web UI.

## How Has This Been Tested?

New unit test, manually tested, tested through AEM desktop.

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
