### PR TITLE
add foldercreated event. create folders even when empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ options.withUploadFiles([
                 <br/>
                 <b>Example</b>
                 <br/>
-                <code>import { HttpProxy } from '@adobe/aem-upload';
+                <code>import { HttpProxy } from '@adobe/aem-upload';</code>
                 <br/>
                 <code>options.withHttpProxy(</code>
                 <br/>
@@ -621,6 +621,48 @@ through the stages of uploading a file. These events are listed below.
                 A simple javascript <code>object</code> containing the same properties as "filestart."
             </td>
         </tr>
+        <tr>
+            <td>foldercreated</td>
+            <td>
+                Indicates that the upload process created a new folder in the target.
+            </td>
+            <td>
+                The data sent with the event will be a simple javascript <code>object</code>
+                with the following properties:
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Property</th>
+                            <th>Type</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody style="vertical-align: top">
+                        <tr>
+                            <td>folderName</td>
+                            <td>string</td>
+                            <td>
+                                The name (i.e. title) of the folder, as it was created. This will <i>not</i> be a URI encoded value.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>targetParent</td>
+                            <td>number</td>
+                            <td>
+                                Full path to the AEM folder where the folder was created. This will <i>not</i> be a URI encoded value.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>targetFolder</td>
+                            <td>string</td>
+                            <td>
+                                Full path to the AEM folder that was created. This will <i>not</i> be a URI encoded value.
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
     </tbody>
 </table>
 
@@ -687,6 +729,13 @@ controller.cancel();
 
 The library supports uploading local files and folders. For folders, the tool
 will include all immediate children files in the folder. It will not process sub-folders unless the "deep upload" option is specified.
+
+When deep uploading, the library will create a folder structure in the target that mirrors the folder being uploaded. The title of the newly
+created folders will match the name of the folder as it exists on the local filesystem. The path of the target may be modified depending on
+path character restrictions in AEM, and depending on the options provided in the upload (see "Function for processing folder node names" for
+more information).
+
+Whenever the library creates a new folder, it will emit the `foldercreated` event. See event documentation for details.
 
 The following example illustrates how to upload local files.
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -347,23 +347,6 @@ async function processDirectory(directoryPath, directories, files, errors) {
     return totalSize;
 }
 
-function removeEmptyDirectories(directories, files) {
-    const validDirectories = [];
-    for (let d = 0; d < directories.length; d++) {
-        const directory = directories[d];
-        const directoryPrefix = Path.join(directory.path, '/');
-        for (let f = 0; f < files.length; f++) {
-            const file = files[f];
-            if (file.path.startsWith(directoryPrefix)) {
-                validDirectories.push(directory);
-                break;
-            }
-        }
-    }
-    
-    return validDirectories;
-}
-
 /**
  * Walks a directory by retrieving all the directories and files
  * in the given path, then walking all those sub directories, then
@@ -403,7 +386,7 @@ export async function walkDirectory(directoryPath, maximumPaths = 5000, includeD
     }
 
     return {
-        directories: removeEmptyDirectories(allDirectories, allFiles),
+        directories: allDirectories,
         files: allFiles,
         errors: allErrors,
         totalSize: walkedTotalSize

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -92,6 +92,7 @@ module.exports.monitorEvents = (toMonitor) => {
     toMonitor.on('fileend', data => events.push({ event: 'fileend', data }));
     toMonitor.on('fileerror', data => events.push({ event: 'fileerror', data }));
     toMonitor.on('filecancelled', data => events.push({ event: 'filecancelled', data }));
+    toMonitor.on('foldercreated', data => events.push({ event: 'foldercreated', data }));
 }
 
 /**
@@ -114,6 +115,33 @@ module.exports.getEvent = (eventName, targetFile) => {
             const expectedTargetFolder = targetFile.substr(0, lastSlash);
             should(fileName).be.exactly(expectedFileName);
             should(targetFolder).be.exactly(expectedTargetFolder);
+
+            return data;
+        }
+    }
+    return false;
+}
+
+/**
+ * Determines if an event with a matching "targetFolder" value was emitted since the
+ * last invocation of monitorEvents(). If found, the event's other data values will
+ * be validated.
+ * @param {string} eventName Name of the expected event.
+ * @param {string} targetFolder Value of the "targetFolder" event data property for the
+ *  expected event.
+ * @returns {object|boolean} The event's data if found, otherwise false.
+ */
+module.exports.getFolderEvent = (eventName, targetFolder) => {
+    for (let i = 0; i < events.length; i++) {
+        const { event, data } = events[i];
+
+        if (event === eventName && data.targetFolder === targetFolder) {
+            const { folderName, targetParent } = data;
+            const lastSlash = targetFolder.lastIndexOf('/');
+            const expectedFolderName = targetFolder.substr(lastSlash + 1);
+            const expectedTargetParent = targetFolder.substr(0, lastSlash);
+            should(folderName).be.exactly(expectedFolderName);
+            should(targetParent).be.exactly(expectedTargetParent);
 
             return data;
         }

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -217,7 +217,7 @@ describe('UtilsTest', function () {
         createDirectoryStructure();
 
         const { directories, files, totalSize, errors } = await walkDirectory('/root');
-        should(directories.length).be.exactly(3);
+        should(directories.length).be.exactly(6);
         should(files.length).be.exactly(6);
         should(totalSize).be.exactly(files.length * 1024);
         should(errors.length).be.exactly(2);
@@ -225,10 +225,16 @@ describe('UtilsTest', function () {
         const dir1 = getPathIndex(directories, '/root/dir1');
         const dir2 = getPathIndex(directories, '/root/dir1/dir2');
         const dir3 = getPathIndex(directories, '/root/dir1/dir2/dir3');
+        const dir4 = getPathIndex(directories, '/root/emptydir');
+        const dir5 = getPathIndex(directories, '/root/emptydir/emptysubdir');
+        const dir6 = getPathIndex(directories, '/root/error');
 
         should(dir1 >= 0 && dir1 > dir2 && dir1 > dir3);
         should(dir2 >= 0 && dir2 > dir3);
         should(dir3 >= 0);
+        should(dir6 >= 0);
+        should(dir4 >= 0);
+        should(dir5 > dir4);
 
         const file1 = getPathIndex(files, '/root/file1.jpg');
         const file2 = getPathIndex(files, '/root/file2.jpg');
@@ -249,7 +255,15 @@ describe('UtilsTest', function () {
         createDirectoryStructure();
 
         const { directories, files, totalSize, errors } = await walkDirectory('/root', 1000, false);
-        should(directories.length).be.exactly(0);
+        should(directories.length).be.exactly(3);
+
+        const dir1 = getPathIndex(directories, '/root/dir1');
+        const dir2 = getPathIndex(directories, '/root/error');
+        const dir3 = getPathIndex(directories, '/root/emptydir');
+        should(dir1 >= 0);
+        should(dir2 >= 0);
+        should(dir3 >= 0);
+
         should(files.length).be.exactly(2);
         should(totalSize).be.exactly(files.length * 1024);
         should(errors.length).be.exactly(1);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Makes the following changes to the filesystem upload process:

* Create folders in AEM even if they don't have files in them. This is a change in current functionality, and will warrant a new minor release.
* Send a new `foldercreated` event whenever the library creates a folder in AEM. Readme has also been updated with information about the new event.
* Don't call `node-httptransfer` if there are no files being uploaded.
* Update unit tests and e2e test to validate new functionality.

## Related Issue

#86 

## Motivation and Context

AEM Desktop uses this library when uploading local files. Before using `aem-upload`, the app would create all folders from the local structure in AEM, even if they were empty. To bring `aem-upload` inline with these requirements, it will be updated so that it no longer filters out empty directories.

In addition, AEM Desktop has no way of updating its UI when `aem-upload` creates a new folder, because `aem-upload` doesn't provide any indication when it has created folders. The new event can be used to update AEM Desktop's UI.

## How Has This Been Tested?

* Existing unit tests and e2e tests pass.
* Added new unit tests for verifying empty directories.
* Updated unit tests and e2e tests to verify new event.
* Uploaded an entirely empty directory structure and verified that all directories were created in AEM.
* Uploaded a mix of empty and non-empty directories, and verified that all directories and files were created in AEM.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
