### PR TITLE
Send all events when uploading with DirectBinaryUpload

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,76 @@ through the stages of uploading a file. These events are listed below.
     </thead>
     <tbody style="vertical-align: top">
         <tr>
+            <td>fileuploadstart</td>
+            <td>Indicates an upload of one or more files is starting.</td>
+            <td>
+                The data sent with the event will be a simple javascript <code>object</code>
+                with the following properties:
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Property</th>
+                            <th>Type</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody style="vertical-align: top">
+                        <tr>
+                            <td>uploadId</td>
+                            <td>string</td>
+                            <td>
+                                A unique identifier that can be used to identify the upload session.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>fileCount</td>
+                            <td>number</td>
+                            <td>
+                                The total number of files that will be uploaded as part of this upload session.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>totalSize</td>
+                            <td>number</td>
+                            <td>
+                                The total size, in bytes, of all files that will be uploaded as part of this upload session.
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>directoryCount</td>
+                            <td>number</td>
+                            <td>The number of directories included in the upload session.</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+        <tr>
+            <td>fileuploadend</td>
+            <td>Indicates an upload of one or more files has finished.</td>
+            <td>
+                The data sent with the event will be the same as the `fileuploadstart` event, with the following additional elements:
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Property</th>
+                            <th>Type</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody style="vertical-align: top">
+                        <tr>
+                            <td>result</td>
+                            <td>object</td>
+                            <td>
+                                Simple javascript object containing the same upload result information that is returned by the library's `upload()` methods.
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+        <tr>
             <td>filestart</td>
             <td>Indicates that a file has started to upload.</td>
             <td>

--- a/src/direct-binary-upload-process.js
+++ b/src/direct-binary-upload-process.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 import querystring from 'querystring';
 import { AEMUpload } from '@adobe/httptransfer/es2015';
 import httpTransferLogger from '@adobe/httptransfer/es2015/logger';
+import { v4 as uuid } from 'uuid';
 
 import InitResponse from './init-response';
 import UploadError from './upload-error';
@@ -81,6 +82,7 @@ export default class DirectBinaryUploadProcess extends FileTransferHandler {
         this.fileEvents = {};
         this.fileTransfer = {};
         this.completeUri = '';
+        this.uploadId = uuid();
 
         const log = options.log;
         if (log) {
@@ -89,6 +91,30 @@ export default class DirectBinaryUploadProcess extends FileTransferHandler {
             httpTransferLogger.warn = (...args) => log.warn.apply(log, args);
             httpTransferLogger.error = (...args) => log.error.apply(log, args);
         }
+    }
+
+    /**
+     * Retrieves a unique identifier that can be used to identify this particular upload.
+     *
+     * @returns {string} ID representing the upload.
+     */
+    getUploadId() {
+        return this.uploadId;
+    }
+
+    /**
+     * Retrieves the total size of the upload, which is determined based on the file size
+     * specified on each upload file.
+     *
+     * @returns {number} Total size, in bytes.
+     */
+    getTotalSize() {
+        let totalSize = 0;
+        this.getUploadOptions().getUploadFiles().forEach((uploadFile) => {
+            const { fileSize = 0 } = uploadFile;
+            totalSize += fileSize;
+        });
+        return totalSize;
     }
 
     /**

--- a/src/direct-binary-upload.js
+++ b/src/direct-binary-upload.js
@@ -33,13 +33,9 @@ export default class DirectBinaryUpload extends UploadBase {
         const uploadProcess = new DirectBinaryUploadProcess(this.getOptions(), options);
         const uploadResult = new UploadResult(this.getOptions(), options);
 
-        uploadProcess.on('filestart', data => this.sendEvent('filestart', data));
-        uploadProcess.on('fileprogress', data => this.sendEvent('fileprogress', data));
-        uploadProcess.on('fileend', data => this.sendEvent('fileend', data));
-        uploadProcess.on('fileerror', data => this.sendEvent('fileerror', data));
-        uploadProcess.on('filecancelled', data => this.sendEvent('filecancelled', data));
-
-        await uploadProcess.upload(uploadResult);
+        this.beforeUploadProcess(uploadProcess);
+        await this.executeUploadProcess(uploadProcess, uploadResult);
+        this.afterUploadProcess(uploadProcess, uploadResult);
 
         return uploadResult;
     }

--- a/src/filesystem-upload.js
+++ b/src/filesystem-upload.js
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 import fs from './fs-promise';
 import Path from 'path';
-import { v4 as uuid } from 'uuid';
 
 import DirectBinaryUpload from './direct-binary-upload';
 import DirectBinaryUploadProcess from './direct-binary-upload-process';

--- a/test/direct-binary-upload-process.test.js
+++ b/test/direct-binary-upload-process.test.js
@@ -189,5 +189,20 @@ describe('DirectBinaryUploadProcessTest', () => {
             should(uploadFile.fileUrl).be.exactly('http://localhost/content/dam/target/file-upload-smoke/fileuploadsmoke.jpg');
             should(uploadFile.fileSize).be.exactly(1024);
         });
+
+        it('test total upload size', function () {
+            const options = new DirectBinaryUploadOptions()
+                .withUploadFiles([{
+                    fileName: 'fileuploadsmoke.jpg',
+                    fileSize: 1024,
+                    filePath: '/test/file/path.jpg'
+                }, {
+                    fileName: 'fileuploadsmoke2.jpg',
+                    fileSize: 2048,
+                    filePath: '/test/file/path2.jpg'
+                }]);
+            const process = new DirectBinaryUploadProcess(getTestOptions(), options);
+            should(process.getTotalSize()).be.exactly(3072);
+        });
     });
 });

--- a/test/direct-binary-upload.test.js
+++ b/test/direct-binary-upload.test.js
@@ -254,6 +254,7 @@ describe('DirectBinaryUploadTest', () => {
             should(events[7].event).be.exactly('fileuploadend');
             should(events[7].data.fileCount).be.exactly(2);
             should(events[7].data.totalSize).be.exactly(3023);
+            should(events[7].data.result).be.ok;
         });
 
         it('direct binary not supported', async() => {
@@ -275,7 +276,15 @@ describe('DirectBinaryUploadTest', () => {
                 });
             });
 
-            await upload.canUpload(options);
+            let threw = false;
+            try {
+                await upload.canUpload(options);
+            } catch (e) {
+                should(e).be.ok();
+                should(e.getCode()).be.exactly(ErrorCodes.NOT_SUPPORTED);
+                threw = true;
+            }
+            should(threw).be.ok();
         });
     });
 });

--- a/test/direct-binary-upload.test.js
+++ b/test/direct-binary-upload.test.js
@@ -71,6 +71,12 @@ function verifyFile2Event(eventName, eventData, folderName = 'folder') {
 }
 
 function monitorEvents(upload) {
+    upload.on('fileuploadstart', data => {
+        events.push({ event: 'fileuploadstart', data });
+    });
+    upload.on('fileuploadend', data => {
+        events.push({ event: 'fileuploadend', data });
+    });
     upload.on('filestart', data => {
         events.push({ event: 'filestart', data });
     });
@@ -197,13 +203,15 @@ describe('DirectBinaryUploadTest', () => {
             should(file2Part1.getError()).not.be.ok();
 
             // verify that events are correct
-            should(events.length).be.exactly(6);
-            verifyFile1Event('filestart', events[0]);
-            verifyFile1Event('fileprogress', events[1]);
-            verifyFile1Event('fileend', events[2]);
-            verifyFile2Event('filestart', events[3]);
-            verifyFile2Event('fileprogress', events[4]);
-            verifyFile2Event('fileend', events[5]);
+            should(events.length).be.exactly(8);
+            should(events[0].event).be.exactly('fileuploadstart');
+            verifyFile1Event('filestart', events[1]);
+            verifyFile1Event('fileprogress', events[2]);
+            verifyFile1Event('fileend', events[3]);
+            verifyFile2Event('filestart', events[4]);
+            verifyFile2Event('fileprogress', events[5]);
+            verifyFile2Event('fileend', events[6]);
+            should(events[7].event).be.exactly('fileuploadend');
         });
 
         it('progress events', async() => {
@@ -223,23 +231,29 @@ describe('DirectBinaryUploadTest', () => {
 
             await upload.uploadFiles(options);
 
-            should(events.length).be.exactly(6);
+            should(events.length).be.exactly(8);
 
-            should(events[0].event).be.exactly('filestart');
-            should(events[0].data.fileName).be.exactly('targetfile.jpg');
-            should(events[1].event).be.exactly('fileprogress');
+            should(events[0].event).be.exactly('fileuploadstart');
+            should(events[0].data.fileCount).be.exactly(2);
+            should(events[0].data.totalSize).be.exactly(3023);
+            should(events[1].event).be.exactly('filestart');
             should(events[1].data.fileName).be.exactly('targetfile.jpg');
-            should(events[1].data.transferred).be.exactly(512);
-            should(events[2].event).be.exactly('fileend');
+            should(events[2].event).be.exactly('fileprogress');
             should(events[2].data.fileName).be.exactly('targetfile.jpg');
+            should(events[2].data.transferred).be.exactly(512);
+            should(events[3].event).be.exactly('fileend');
+            should(events[3].data.fileName).be.exactly('targetfile.jpg');
 
-            should(events[3].event).be.exactly('filestart');
-            should(events[3].data.fileName).be.exactly('targetfile2.jpg');
-            should(events[4].event).be.exactly('fileprogress');
+            should(events[4].event).be.exactly('filestart');
             should(events[4].data.fileName).be.exactly('targetfile2.jpg');
-            should(events[4].data.transferred).be.exactly(512);
-            should(events[5].event).be.exactly('fileend');
+            should(events[5].event).be.exactly('fileprogress');
             should(events[5].data.fileName).be.exactly('targetfile2.jpg');
+            should(events[5].data.transferred).be.exactly(512);
+            should(events[6].event).be.exactly('fileend');
+            should(events[6].data.fileName).be.exactly('targetfile2.jpg');
+            should(events[7].event).be.exactly('fileuploadend');
+            should(events[7].data.fileCount).be.exactly(2);
+            should(events[7].data.totalSize).be.exactly(3023);
         });
 
         it('direct binary not supported', async() => {
@@ -261,15 +275,7 @@ describe('DirectBinaryUploadTest', () => {
                 });
             });
 
-            let threw = false;
-            try {
-                await upload.canUpload(options);
-            } catch (e) {
-                should(e).be.ok();
-                should(e.getCode()).be.exactly(ErrorCodes.NOT_SUPPORTED);
-                threw = true;
-            }
-            should(threw).be.ok();
+            await upload.canUpload(options);
         });
     });
 });


### PR DESCRIPTION
## Description

Fixed `DirectBinaryUpload` so that it correctly sends `fileuploadstart` and `fileuploadend`. Both `DirectBinaryUpload` and `FileSystemUpload` now share code that ensures consistency of events between the two upload methods.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#93 

## Motivation and Context

There's inconsistency between the events that are sent, depending on which method of uploading is used. This will bring the two branches into alignment.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* New unit tests
* Existing unit tests pass
* `e2e` tests pass
* Incorporated updated library into a client application and tested to ensure all events are sent as expected.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
