### PR TITLE
Allow uploads to instances without direct binary upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@
 
 In AEM Assets 6.5 and prior, a single post request to a servlet that manges asset binaries is enough for uploading files. Newer versions of AEM can be configured 
 to use direct binary upload, which means that asset binaries are no longer uploaded straight to AEM. Because of this there is a more complex 
-algorithm to follow when uploading asset binaries. Due to the fact that direct binary upload is a configuration, whether or not this library can be used 
-on a given AEM instance will vary. However, all AEM as a Cloud Service instances will have direct binary upload enabled, so this library will work with those.
+algorithm to follow when uploading asset binaries. This library will check the configuration of the target AEM instance, and will either use the direct binary upload algorithm or the create asset servlet, depending on the configuration.
 
 This tool is provided for making uploading easier, and can be used as a command line executable
 or required as a Node.js module.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@adobe/httptransfer": {
-      "version": "3.2.1",
-      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-platform-release/@adobe/httptransfer/-/httptransfer-3.2.1.tgz",
-      "integrity": "sha512-P6Z1Hr3s/vnVfOx5CF4NQJmK7qKnO1P+QLQy1GdtxY3IBGrlmYXN/wplY2LxeY/tutd9UKw7ogdnO36skGE5AQ==",
+      "version": "3.3.0",
+      "resolved": "https://artifactory.corp.adobe.com/artifactory/api/npm/npm-adobe-platform-release/@adobe/httptransfer/-/httptransfer-3.3.0.tgz",
+      "integrity": "sha512-F9/u26v47dg0qs0I5FhF1Ycto8CUhaI+WxWM2BSwdgxpl8TqYTQPAsfs2ZZJRq2f0IfMKmBX8BesxGfnr6DT3Q==",
       "requires": {
         "@babel/runtime": "^7.16.7",
         "content-disposition": "^0.5.4",
@@ -18,23 +18,24 @@
         "drange": "^2.0.1",
         "file-url": "2.0.2",
         "filter-obj": "^2.0.2",
+        "form-data": "^4.0.0",
         "mime-types": "^2.1.35",
         "node-fetch-npm": "^2.0.4",
         "valid-url": "^1.0.9"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.18.3",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
-          "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
+          "version": "7.20.7",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+          "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
           "requires": {
-            "regenerator-runtime": "^0.13.4"
+            "regenerator-runtime": "^0.13.11"
           }
         },
         "core-js": {
-          "version": "3.22.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.22.7.tgz",
-          "integrity": "sha512-Jt8SReuDKVNZnZEzyEQT5eK6T2RRCXkfTq7Lo09kpm+fHjgGewSbNjV+Wt4yZMhPDdzz2x1ulI5z/w4nxpBseg=="
+          "version": "3.27.2",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.27.2.tgz",
+          "integrity": "sha512-9ashVQskuh5AZEZ1JdQWp1GqSoC1e1G87MzRqg2gIfVAQ7Qn9K+uFj8EcniUFA4P2NLZfV+TOlX1SzoKfo+s7w=="
         },
         "debug": {
           "version": "4.3.4",
@@ -43,6 +44,11 @@
           "requires": {
             "ms": "2.1.2"
           }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.11",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+          "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
         }
       }
     },
@@ -2948,6 +2954,11 @@
       "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.2.8.tgz",
       "integrity": "sha512-G+26B2jc0Gw0EG/WN2M6IczuGepBsfR1+DtqLnyFSH4p2C668qkOCtEkGNVEaaNAVlYwEMazy1+/jnLxltBkIQ=="
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "axios": {
       "version": "0.21.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
@@ -3254,6 +3265,14 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "commander": {
       "version": "4.1.1",
@@ -3588,6 +3607,11 @@
           "optional": true
         }
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "deprecation": {
       "version": "2.3.1",
@@ -4239,6 +4263,16 @@
       "requires": {
         "cross-spawn": "^4",
         "signal-exit": "^3.0.0"
+      }
+    },
+    "form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
       }
     },
     "from2": {
@@ -9843,7 +9877,7 @@
     "valid-url": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "bugs": "https://github.com/adobe/aem-upload",
   "dependencies": {
-    "@adobe/httptransfer": "^3.2.1",
+    "@adobe/httptransfer": "^3.3.0",
     "async": "^3.2.0",
     "async-lock": "^1.2.8",
     "axios": "^0.21.4",

--- a/src/direct-binary-upload.js
+++ b/src/direct-binary-upload.js
@@ -52,12 +52,11 @@ export default class DirectBinaryUpload extends UploadBase {
      *  documentation for details.
      */
     async canUpload(options) {
-        const uploadProcess = new DirectBinaryUploadProcess(this.getOptions(), options);
-
-        await uploadProcess.initiateUpload(new UploadResult(this.getOptions(), options), [{
-            fileName: `${new Date().getTime()}_canUploadTest.jpg`,
-            fileSize: 1,
-            blob: [1]
-        }]);
+        // this is a legacy option, but leaving the method in place for backward compatibility. The library
+        // previously only worked if direct binary upload was enabled on AEM. However, the capabilities
+        // of node-httptransfer were updated so that it could upload using the create asset servlet if
+        // direct binary upload is not available. So the upload process will now work with any AEM instance,
+        // regardless of its configuration
+        return true;
     }
 }

--- a/src/direct-binary-upload.js
+++ b/src/direct-binary-upload.js
@@ -51,6 +51,7 @@ export default class DirectBinaryUpload extends UploadBase {
      * @param {DirectBinaryUploadOptions} options Options for the proposed upload. See module
      *  documentation for details.
      */
+    // eslint-disable-next-line no-unused-vars
     async canUpload(options) {
         // this is a legacy option, but leaving the method in place for backward compatibility. The library
         // previously only worked if direct binary upload was enabled on AEM. However, the capabilities

--- a/test/direct-binary-upload.test.js
+++ b/test/direct-binary-upload.test.js
@@ -261,15 +261,7 @@ describe('DirectBinaryUploadTest', () => {
                 });
             });
 
-            let threw = false;
-            try {
-                await upload.canUpload(options);
-            } catch (e) {
-                should(e).be.ok();
-                should(e.getCode()).be.exactly(ErrorCodes.NOT_SUPPORTED);
-                threw = true;
-            }
-            should(threw).be.ok();
+            await upload.canUpload(options);
         });
     });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

`node-httptransfer` was recently updated so that it can upload to AEM instances that don't have direct binary upload enabled. In these cases, it will fall back to using the create asset servlet.

This PR updates to a version of `node-httptransfer` that supports "legacy" instances, and changes the behavior of this module when checking to see if it can upload to a target instance.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#95 

## Motivation and Context

Now this module can be used to efficiently upload files to _any_ instance of AEM, not just those that have direct binary upload enabled. This will help simplify consumers of the library that might need to be able to upload to legacy AEM configurations; now these clients can use this single library and not need to come up with their own process for uploading files.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

* Existing unit tests and e2e tests pass.
* Updated a consuming client locally and tested that uploading to a legacy AEM instance works.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
