### PR TITLE
Proxy and Self Signed Certificate Support

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [6.10.3, 8.2.1, 10.16, 10.19, 12.16, 12.19]
+        node-version: [10.16, 10.19, 12.16, 12.19, 14.16.1, 14.17, 16.13]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.16, 10.19, 12.16, 12.19, 14.16.1, 14.17, 16.13]
+        node-version: [10.16, 10.19, 12.16, 12.19, 14.16.1, 14.17]
 
     steps:
     - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -2758,11 +2758,6 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
-    "@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
-    },
     "@types/minimist": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -2813,6 +2808,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "optional": true,
       "requires": {
         "debug": "4"
       }
@@ -4626,26 +4622,22 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
+    "hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "http-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-      "requires": {
-        "@tootallnate/once": "2",
-        "agent-base": "6",
-        "debug": "4"
-      }
-    },
     "https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "optional": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -9877,7 +9869,7 @@
     "valid-url": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
-      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
+      "integrity": "sha1-HBRHm0DxOXp1eC8RXkCGRHQzogA="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "cookie": "^0.4.1",
     "core-js": "^3.6.4",
     "filesize": "^4.2.1",
-    "http-proxy-agent": "^5.0.0",
-    "https-proxy-agent": "^5.0.1",
+    "hpagent": "^1.2.0",
     "regenerator-runtime": "^0.13.5",
     "uuid": "^3.3.2"
   },

--- a/src/http-utils.js
+++ b/src/http-utils.js
@@ -201,12 +201,11 @@ function getHttpTransferOptions(options, directBinaryUploadOptions) {
     //  strictSSL/rejectUnauthorized, or both
     const { protocol = 'http:' } = URL.parse(directBinaryUploadOptions.getUrl());
     const proxyOptions = getProxyAgentOptions(directBinaryUploadOptions);
-    if (proxyOptions) {
+    if (proxyOptions && proxyOptions.href) {
       const agentOptions = {};
 
       // TODO: figure out how to assemble proxy url
-      const proxy = proxyOptions.href ? proxyOptions.href : `${proxyOptions.protocol}://${proxyOptions.host}:${proxyOptions.port}/`;
-      agentOptions.proxy = proxy;
+      agentOptions.proxy = proxyOptions.href;
 
       if (typeof options.strictSSL !== 'undefined') {
         agentOptions.rejectUnauthorized = options.strictSSL;

--- a/src/http/http-request.js
+++ b/src/http/http-request.js
@@ -36,6 +36,10 @@ class HttpRequest extends UploadBase {
             method: HttpRequest.Method.GET,
             timeout: DefaultValues.REQUEST_TIMEOUT,
         };
+        // special handling to allow configurable support for self-signed certificates
+        if (typeof options.strictSSL !== 'undefined') {
+          this.requestOptions.strictSSL = options.strictSSL;
+        }
         this.headers = {};
         this.cancelId = '';
         this.totalTransferred = 0;

--- a/test/filesystem-upload.test.js
+++ b/test/filesystem-upload.test.js
@@ -184,7 +184,7 @@ describe('FileSystemUpload Tests', () => {
             const uploadOptions = new FileSystemUploadOptions()
                 .withUrl(MockRequest.getUrl('/folder/structure'))
                 .withBasicAuth('testauth')
-                .withHttpProxy(new HttpProxy('http://somereallyfakeproxyhost'));
+                .withHttpProxy(new HttpProxy('http://somereallyfakeproxyhost:3128'));
             const path1Dir = new FileSystemUploadDirectory(uploadOptions, '/prefix/path1', 'path1');
             const fsUpload = new FileSystemUpload(getTestOptions());
             await fsUpload.createUploadDirectories(uploadOptions, httpClient, [
@@ -200,15 +200,15 @@ describe('FileSystemUpload Tests', () => {
             // confirm proxy details - requests made with axios
             should(posts[0].proxy).equal(false);
             should(posts[0].httpAgent).be.ok();
-            should(posts[0].httpAgent.proxy.host).be.exactly('somereallyfakeproxyhost');
+            should(posts[0].httpAgent.proxy.hostname).be.exactly('somereallyfakeproxyhost');
             should(posts[1].url).be.exactly(MockRequest.getApiUrl('/folder/structure/path1/dir1'))
             should(posts[1].proxy).equal(false);
             should(posts[1].httpAgent).be.ok();
-            should(posts[1].httpAgent.proxy.host).be.exactly('somereallyfakeproxyhost');
+            should(posts[1].httpAgent.proxy.hostname).be.exactly('somereallyfakeproxyhost');
             should(posts[2].url).be.exactly(MockRequest.getApiUrl('/folder/structure/path1/dir2'))
             should(posts[2].proxy).equal(false);
             should(posts[2].httpAgent).be.ok();
-            should(posts[2].httpAgent.proxy.host).be.exactly('somereallyfakeproxyhost');
+            should(posts[2].httpAgent.proxy.hostname).be.exactly('somereallyfakeproxyhost');
         });
 
         function buildPostLookup() {

--- a/test/http-utils.test.js
+++ b/test/http-utils.test.js
@@ -58,9 +58,9 @@ describe('HttpUtilsTest', () => {
                 should(requestOptions.httpsAgent).not.be.ok();
                 should(requestOptions.httpAgent).be.ok();
                 should(requestOptions.httpAgent.proxy).be.ok();
-                should(requestOptions.httpAgent.proxy.host).equal('myproxy');
-                should(requestOptions.httpAgent.proxy.port).equal(8080);
-                should(requestOptions.httpAgent.proxy.protocol).equal('http');
+                should(requestOptions.httpAgent.proxy.hostname).equal('myproxy');
+                should(requestOptions.httpAgent.proxy.port).equal('8080');
+                should(requestOptions.httpAgent.proxy.protocol).equal('http:');
                 return new Promise(resolve => {
                     setTimeout(() => {
                         resolve([200, { success: true }]);
@@ -78,14 +78,14 @@ describe('HttpUtilsTest', () => {
             }, {});
         });
 
-        it('proxy to https endpoint (requests made with axios)', async () => {
+        it.('proxy to https endpoint (requests made with axios)', async () => {
             MockRequest.onGet('https://timedrequestunittest').reply((requestOptions) => {
                 should(requestOptions.httpAgent).not.be.ok();
                 should(requestOptions.httpsAgent).be.ok();
                 should(requestOptions.httpsAgent.proxy).be.ok();
-                should(requestOptions.httpsAgent.proxy.host).equal('myproxy');
-                should(requestOptions.httpsAgent.proxy.port).equal(8080);
-                should(requestOptions.httpsAgent.proxy.protocol).equal('http');
+                should(requestOptions.httpsAgent.proxy.hostname).equal('myproxy');
+                should(requestOptions.httpsAgent.proxy.port).equal('8080');
+                should(requestOptions.httpsAgent.proxy.protocol).equal('http:');
                 return new Promise(resolve => {
                     setTimeout(() => {
                         resolve([200, { success: true }]);

--- a/test/http/http-request.test.js
+++ b/test/http/http-request.test.js
@@ -62,7 +62,7 @@ describe('HTTP Request Tests', function() {
     });
 
     it('test accessors', function() {
-        const request = new HttpRequest(getTestOptions(), HOST)
+        const request = new HttpRequest(getTestOptions({ strictSSL: false }), HOST)
         .withUploadOptions(new DirectBinaryUploadOptions()
             .withHeaders({
                 uploadHeader: 'upload',
@@ -91,7 +91,8 @@ describe('HTTP Request Tests', function() {
             data,
             responseType,
             timeout,
-            proxy
+            proxy,
+            strictSSL
         } = options;
 
         should(url).be.exactly(HOST);
@@ -104,6 +105,7 @@ describe('HTTP Request Tests', function() {
             protocol: 'http',
             port: 1234
         });
+        should(strictSSL).be.exactly(false);
 
         const {
             header1,

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -13,6 +13,7 @@ governing permissions and limitations under the License.
 require('core-js');
 require('regenerator-runtime');
 
+const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
 const proxyquire = require('proxyquire').noCallThru();
 const should = require('should');
 
@@ -33,7 +34,7 @@ module.exports.getImportPath = getImportPath;
  *  is in the project, the name should be the relative path to the file from the src/ directory (such
  *  as "./upload-file").
  */
-module.exports.importFile = (file, fileMocks) => {
+function importFile(file, fileMocks) {
     const requirePath = getImportPath(file);
     let required;
     if (fileMocks) {
@@ -46,6 +47,7 @@ module.exports.importFile = (file, fileMocks) => {
     }
     return required;
 }
+module.exports.importFile = importFile;
 
 function getConsoleLogger() {
     return {
@@ -75,6 +77,34 @@ module.exports.getTestOptions = (addlOptions = {}) => {
         }
     }
     return addlOptions;
+}
+
+/**
+ * Retrieves high level direct binary upload options common for many tests.
+ * @returns {object} Options for a direct binary upload operation.
+ */
+module.exports.getTestUploadOptions = () => {
+    return new DirectBinaryUploadOptions()
+        .withConcurrent(false)
+        .withHeaders({
+            hello: 'world!'
+        })
+        .withUploadFiles([{
+            fileSize: 1024,
+            fileName: 'file.jpg',
+            filePath: '/my/test/file.jpg',
+            createVersion: true,
+            versionComment: 'My Comment',
+            versionLabel: 'Version Label',
+            replace: true,
+            partHeaders: {
+                part: 'header'
+            }
+        }, {
+            fileSize: 2048,
+            fileName: 'blob-file.jpg',
+            blob: [1, 2, 3]
+        }]);
 }
 
 // stores events for monitorEvents().


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adjust HTTP agent usage on requests to support both proxies, and/or self-signed certificates. The HTTP agent library has been switched to [hpagent](https://github.com/delvedor/hpagent) to support both of these cases (unfortunately previous proxy agent library did not support required setting required `rejectUnauthorized` option).

Self-signed certificates can be enabled by adding `strictSSL: false` to the `options` object provided to `UploadBase` classes. For example:

```
const uploadOptions = { 
  strictSSL: fase 
}

const fileUpload = new FileSystemUpload(uploadOptions);
```

The configuration option was passed in this way so it is available during both `getHttpTransferOptions()` and `timedRequest()` in HTTP Utils.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

ASSETS-22279

## Motivation and Context

The AEM Desktop App supports self-signed certificates via the `strictSSL=false` config option documented here: https://experienceleague.adobe.com/docs/experience-manager-desktop-app/using/troubleshoot.html (see "SSL configuration issue" section).

## How Has This Been Tested?

- Unit tests have been written to cover updated logic
- Tested AEM Desktop app with these changes; tested with and without proxies, SSL proxying, and connecting directory to AEM instance with self-signed certificate

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
