### PR TITLE
switch to using non-module specific syntax.

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ options.withUploadFiles([
                 <br/>
                 <b>Example</b>
                 <br/>
-                <code>import { HttpProxy } from '@adobe/aem-upload';</code>
+                <code>const { HttpProxy } = require('@adobe/aem-upload');</code>
                 <br/>
                 <code>options.withHttpProxy(</code>
                 <br/>

--- a/e2e/filesystem-upload.test.js
+++ b/e2e/filesystem-upload.test.js
@@ -16,7 +16,6 @@ const Path = require('path');
 const should = require('should');
 
 const {
-  importFile,
   getTargetFolder,
   getTestOptions,
   setCredentials,
@@ -29,9 +28,11 @@ const {
   verifyE2eResult,
 } = require('./e2eutils');
 
-const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
-const FileSystemUploadOptions = importFile('filesystem-upload-options');
-const FileSystemUpload = importFile('filesystem-upload');
+const {
+  DirectBinaryUploadOptions,
+  FileSystemUploadOptions,
+  FileSystemUpload,
+} = require('..');
 
 const ENCODED_ASSET1 = `${decodeURI('%ec%9d%b4%eb%91%90%e5%90%8f%e8%ae%80')}.jpg`;
 const ENCODED_FOLDER = `folder_${decodeURI('%e2%99%82%e2%99%80%c2%b0%e2%80%b2%e2%80%b3%e2%84%83%ef%bc%84%ef%bf%a1%e2%80%b0%c2%a7%e2%84%96%ef%bf%a0%e2%84%a1%e3%88%b1')}`;

--- a/index.js
+++ b/index.js
@@ -10,7 +10,4 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-require('core-js');
-require('regenerator-runtime');
-
-module.exports = require('./dist/exports');
+module.exports = require('./src/exports');

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,9 @@
         "async-lock": "^1.2.8",
         "axios": "^0.21.4",
         "cookie": "^0.4.1",
-        "core-js": "^3.6.4",
         "filesize": "^4.2.1",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.1",
-        "regenerator-runtime": "^0.13.5",
         "uuid": "^3.3.2"
       },
       "devDependencies": {
@@ -40,7 +38,6 @@
         "mocha": "6.2.3",
         "mock-fs": "^4.13.0",
         "nyc": "14.1.1",
-        "proxyquire": "^2.1.3",
         "rimraf": "^3.0.2",
         "should": "^13.2.3",
         "sinon": "^9.2.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@babel/polyfill": "^7.8.7",
         "@babel/preset-env": "^7.9.0",
         "@babel/preset-stage-2": "^7.8.3",
-        "@babel/register": "^7.9.0",
         "@semantic-release/git": "^9.0.0",
         "axios-mock-adapter": "^1.18.1",
         "conventional-changelog-eslint": "^3.0.9",
@@ -1646,25 +1645,6 @@
       "integrity": "sha512-dStnEQgejNYIHFNACdDCigK4BF7wgW6Zahv9Dc2un7rGjbeVtZhBfR3sy0I7ZJOhBexkFxVdMZ5hqmll7BFShw==",
       "dev": true
     },
-    "node_modules/@babel/register": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.21.0.tgz",
-      "integrity": "sha512-9nKsPmYDi5DidAqJaQooxIhsLJiNMkGr8ypQ8Uic7cIox7UCDsM7HuUGxdGT7mSDTYbqzIdsOWzfBton/YJrMw==",
-      "dev": true,
-      "dependencies": {
-        "clone-deep": "^4.0.1",
-        "find-cache-dir": "^2.0.0",
-        "make-dir": "^2.1.0",
-        "pirates": "^4.0.5",
-        "source-map-support": "^0.5.16"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/regjsgen": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
@@ -2503,7 +2483,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2799,12 +2779,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
-    },
     "node_modules/caching-transform": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-3.0.2.tgz",
@@ -3023,20 +2997,6 @@
       "dev": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/clone-deep": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
-      "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
-      "dev": true,
-      "dependencies": {
-        "is-plain-object": "^2.0.4",
-        "kind-of": "^6.0.2",
-        "shallow-clone": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
@@ -4209,19 +4169,6 @@
         "node": ">= 0.4.0"
       }
     },
-    "node_modules/fill-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
-      "dev": true,
-      "dependencies": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -5002,7 +4949,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.8.19"
       }
@@ -5266,15 +5213,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
-      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
@@ -5298,18 +5236,6 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "devOptional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5438,15 +5364,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "devOptional": true
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/issue-parser": {
       "version": "6.0.0",
@@ -6054,12 +5971,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
-      "dev": true
-    },
     "node_modules/merge-source-map": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
@@ -6186,7 +6097,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
       "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -6422,12 +6333,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/module-not-found-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
-      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -10027,15 +9932,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/pirates": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.5.tgz",
-      "integrity": "sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/pkg-conf": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
@@ -10203,17 +10099,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "devOptional": true
-    },
-    "node_modules/proxyquire": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
-      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
-      "dev": true,
-      "dependencies": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.1",
-        "resolve": "^1.11.1"
-      }
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -10945,18 +10830,6 @@
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dev": true,
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -11142,16 +11015,6 @@
       "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
       }
     },
     "node_modules/spawn-error-forwarder": {
@@ -11671,7 +11534,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/through": {
       "version": "2.3.8",
@@ -12201,7 +12064,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "npm run lint && npm run testOnly",
     "testOnly": "mocha --recursive ./test",
-    "build": "/rimraf dist && babel ./src --out-dir dist",
+    "build": "rimraf dist && babel ./src --out-dir dist",
     "prepublishOnly": "npm test && npm run build",
     "coverage": "nyc npm run test",
     "lint": "eslint .",
@@ -40,7 +40,6 @@
     "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-stage-2": "^7.8.3",
-    "@babel/register": "^7.9.0",
     "@semantic-release/git": "^9.0.0",
     "axios-mock-adapter": "^1.18.1",
     "conventional-changelog-eslint": "^3.0.9",

--- a/package.json
+++ b/package.json
@@ -7,13 +7,14 @@
   "license": "Apache-2.0",
   "repository": "adobe/aem-upload",
   "scripts": {
-    "test": "./node_modules/.bin/mocha --recursive --require @babel/register ./test",
-    "build": "./node_modules/.bin/rimraf dist && ./node_modules/.bin/babel ./src --out-dir dist",
+    "test": "npm run lint && npm run testOnly",
+    "testOnly": "mocha --recursive ./test",
+    "build": "/rimraf dist && babel ./src --out-dir dist",
     "prepublishOnly": "npm test && npm run build",
-    "coverage": "./node_modules/.bin/nyc npm run test",
-    "lint": "./node_modules/.bin/eslint .",
-    "lint:fix": "./node_modules/.bin/eslint . --fix",
-    "e2e": "./node_modules/.bin/mocha --recursive --require @babel/register ./e2e",
+    "coverage": "nyc npm run test",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "e2e": "mocha --recursive ./e2e",
     "semantic-release": "semantic-release"
   },
   "author": "Adobe",
@@ -28,11 +29,9 @@
     "async-lock": "^1.2.8",
     "axios": "^0.21.4",
     "cookie": "^0.4.1",
-    "core-js": "^3.6.4",
     "filesize": "^4.2.1",
     "http-proxy-agent": "^5.0.0",
     "https-proxy-agent": "^5.0.1",
-    "regenerator-runtime": "^0.13.5",
     "uuid": "^3.3.2"
   },
   "devDependencies": {
@@ -54,7 +53,6 @@
     "mocha": "6.2.3",
     "mock-fs": "^4.13.0",
     "nyc": "14.1.1",
-    "proxyquire": "^2.1.3",
     "rimraf": "^3.0.2",
     "should": "^13.2.3",
     "sinon": "^9.2.3"

--- a/src/constants.js
+++ b/src/constants.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 /**
  * Constant values that are used as defaults.
  */
-export const DefaultValues = {
+module.exports.DefaultValues = {
   /**
    * The default number of maximum concurrent HTTP requests allowed by the library.
    */
@@ -44,7 +44,7 @@ export const DefaultValues = {
   MAX_FILE_UPLOAD: 1000,
 };
 
-export const RegularExpressions = {
+module.exports.RegularExpressions = {
   /**
    * Will match values that contain characters that are invalid in AEM node
    * names.

--- a/src/create-directory-result.js
+++ b/src/create-directory-result.js
@@ -10,13 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import HttpResult from './http-result';
+const HttpResult = require('./http-result');
 
 /**
  * Represents the results of the creation of a directory. These results contain information such as
  * the amount of time it took to create, and any error that may have occurred.
  */
-export default class CreateDirectoryResult extends HttpResult {
+class CreateDirectoryResult extends HttpResult {
   /**
    * Constructs a new instance using the provided information. Can then be used to provide
    * additional details as needed.
@@ -49,7 +49,7 @@ export default class CreateDirectoryResult extends HttpResult {
   /**
    * Sets the error that was the result of the create request.
    *
-   * @param {import('./upload-error').default} error Error to the create request.
+   * @param {import('./upload-error')} error Error to the create request.
    */
   setCreateError(error) {
     this.error = error;
@@ -104,3 +104,5 @@ export default class CreateDirectoryResult extends HttpResult {
     return json;
   }
 }
+
+module.exports = CreateDirectoryResult;

--- a/src/direct-binary-upload-controller.js
+++ b/src/direct-binary-upload-controller.js
@@ -10,13 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import UploadBase from './upload-base';
+const UploadBase = require('./upload-base');
 
 /**
  * Provides various capabilities for interacting with and controlling an in-progress
  * upload.
  */
-export default class DirectBinaryUploadController extends UploadBase {
+class DirectBinaryUploadController extends UploadBase {
   /**
    * Instructs the upload to cancel the entire upload process.
    */
@@ -31,3 +31,5 @@ export default class DirectBinaryUploadController extends UploadBase {
     this.sendEvent('cancel', { fileName: targetFilePath });
   }
 }
+
+module.exports = DirectBinaryUploadController;

--- a/src/direct-binary-upload-options.js
+++ b/src/direct-binary-upload-options.js
@@ -10,13 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import URL from 'url';
-import cookie from 'cookie';
-import util from 'util';
+const URL = require('url');
+const cookie = require('cookie');
+const util = require('util');
 
-import DirectBinaryUploadController from './direct-binary-upload-controller';
-import { trimRight } from './utils';
-import { DefaultValues } from './constants';
+const DirectBinaryUploadController = require('./direct-binary-upload-controller');
+const { trimRight } = require('./utils');
+const { DefaultValues } = require('./constants');
 
 /**
  * Options that generally control how a direct binary upload will behave. The class contains
@@ -394,4 +394,4 @@ class DirectBinaryUploadOptions {
   }
 }
 
-export default DirectBinaryUploadOptions;
+module.exports = DirectBinaryUploadOptions;

--- a/src/direct-binary-upload-process.js
+++ b/src/direct-binary-upload-process.js
@@ -10,15 +10,17 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { AEMUpload } from '@adobe/httptransfer/es2015';
-import httpTransferLogger from '@adobe/httptransfer/es2015/logger';
-import { v4 as uuid } from 'uuid';
+const {
+  AEMUpload,
+  logger: httpTransferLogger,
+} = require('@adobe/httptransfer');
+const { v4: uuid } = require('uuid');
 
-import UploadOptionsBase from './upload-options-base';
-import FileUploadResults from './file-upload-results';
-import {
+const UploadOptionsBase = require('./upload-options-base');
+const FileUploadResults = require('./file-upload-results');
+const {
   getHttpTransferOptions,
-} from './http-utils';
+} = require('./http-utils');
 
 /**
  * Contains all logic for the process that uploads a set of files using direct binary access.
@@ -47,7 +49,7 @@ import {
  *   will include these additional elements:
  *   * {Array} errors: List of errors that occurred to prevent the upload.
  */
-export default class DirectBinaryUploadProcess extends UploadOptionsBase {
+class DirectBinaryUploadProcess extends UploadOptionsBase {
   /**
    * Constructs a new instance of the upload process for a single directory.
    * @param {object} options Overall direct binary process options.
@@ -101,7 +103,7 @@ export default class DirectBinaryUploadProcess extends UploadOptionsBase {
   /**
    * Does the work of uploading all files based on the upload options provided to the process.
    *
-   * @param {import('./upload-result').default} uploadResult Result to which information about
+   * @param {import('./upload-result')} uploadResult Result to which information about
    *  the upload will be added.
    * @returns {Promise} Resolves when all files have been uploaded.
    */
@@ -144,3 +146,5 @@ export default class DirectBinaryUploadProcess extends UploadOptionsBase {
     this.logInfo(`Uploading result in JSON: ${JSON.stringify(uploadResult, null, 4)}`);
   }
 }
+
+module.exports = DirectBinaryUploadProcess;

--- a/src/direct-binary-upload.js
+++ b/src/direct-binary-upload.js
@@ -10,15 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import UploadBase from './upload-base';
-import DirectBinaryUploadProcess from './direct-binary-upload-process';
-import UploadResult from './upload-result';
+const UploadBase = require('./upload-base');
+const DirectBinaryUploadProcess = require('./direct-binary-upload-process');
+const UploadResult = require('./upload-result');
 
 /**
  * Provides capabilities for uploading assets to an AEM instance configured with
  * direct binary access.
  */
-export default class DirectBinaryUpload extends UploadBase {
+class DirectBinaryUpload extends UploadBase {
   /**
    * Uploads multiple files to a target AEM instance. Through configuration,
    * supports various potential sources, including a node.js process or a
@@ -57,3 +57,5 @@ export default class DirectBinaryUpload extends UploadBase {
     return true;
   }
 }
+
+module.exports = DirectBinaryUpload;

--- a/src/error-codes.js
+++ b/src/error-codes.js
@@ -13,7 +13,7 @@ governing permissions and limitations under the License.
 /**
  * The error codes that the upload process might provide to the consumer.
  */
-export default {
+module.exports = {
   /**
    * The "catch all" error code that is used in cases where the specific error type cannot
    * be determined.

--- a/src/exports.js
+++ b/src/exports.js
@@ -1,7 +1,7 @@
 /*
 Copyright 2019 Adobe. All rights reserved.
-This file is licensed to you under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License. You may obtain a copy
+This file is licensed to you under the Apache License, Version 2.0 (the "License");
 of the License at http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software distributed under
@@ -10,25 +10,18 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import DirectBinaryUploadImport from './direct-binary-upload';
-import DirectBinaryUploadOptionsImport from './direct-binary-upload-options';
-import DirectBinaryUploadErrorCodesImport from './error-codes';
-import FileSystemUploadImport from './filesystem-upload';
-import FileSystemUploadOptionsImport from './filesystem-upload-options';
-import HttpProxyImport from './http-proxy';
+const DirectBinaryUpload = require('./direct-binary-upload');
+const DirectBinaryUploadOptions = require('./direct-binary-upload-options');
+const DirectBinaryUploadErrorCodes = require('./error-codes');
+const FileSystemUpload = require('./filesystem-upload');
+const FileSystemUploadOptions = require('./filesystem-upload-options');
+const HttpProxy = require('./http-proxy');
 
-export default {
-  DirectBinaryUpload: DirectBinaryUploadImport,
-  DirectBinaryUploadOptions: DirectBinaryUploadOptionsImport,
-  DirectBinaryUploadErrorCodes: DirectBinaryUploadErrorCodesImport,
-  FileSystemUpload: FileSystemUploadImport,
-  FileSystemUploadOptions: FileSystemUploadOptionsImport,
-  HttpProxy: HttpProxyImport,
+module.exports = {
+  DirectBinaryUpload,
+  DirectBinaryUploadOptions,
+  DirectBinaryUploadErrorCodes,
+  FileSystemUpload,
+  FileSystemUploadOptions,
+  HttpProxy,
 };
-
-export const DirectBinaryUpload = DirectBinaryUploadImport;
-export const DirectBinaryUploadOptions = DirectBinaryUploadOptionsImport;
-export const DirectBinaryUploadErrorCodes = DirectBinaryUploadErrorCodesImport;
-export const FileSystemUpload = FileSystemUploadImport;
-export const FileSystemUploadOptions = FileSystemUploadOptionsImport;
-export const HttpProxy = HttpProxyImport;

--- a/src/file-upload-results.js
+++ b/src/file-upload-results.js
@@ -10,15 +10,15 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { getAverage } from './utils';
-import UploadOptionsBase from './upload-options-base';
+const { getAverage } = require('./utils');
+const UploadOptionsBase = require('./upload-options-base');
 
-export default class FileUploadResults extends UploadOptionsBase {
+class FileUploadResults extends UploadOptionsBase {
   /**
    * Constructs a new instance using the provided information.
    *
    * @param {object} options Options as provided when the direct binary object was instantiated.
-   * @param {import('./direct-binary-upload-options').default} uploadOptions Options as provided
+   * @param {import('./direct-binary-upload-options')} uploadOptions Options as provided
    *  when the direct binary upload process was initiated.
    */
   constructor(options, uploadOptions) {
@@ -129,3 +129,5 @@ export default class FileUploadResults extends UploadOptionsBase {
     return Object.keys(this.fileLookup).map((path) => this.fileLookup[path]);
   }
 }
+
+module.exports = FileUploadResults;

--- a/src/filesystem-upload-asset.js
+++ b/src/filesystem-upload-asset.js
@@ -17,9 +17,9 @@ governing permissions and limitations under the License.
  * of the upload.
  */
 
-import FileSystemUploadDirectory from './filesystem-upload-directory';
+const FileSystemUploadDirectory = require('./filesystem-upload-directory');
 
-export default class FileSystemUploadAsset extends FileSystemUploadDirectory {
+class FileSystemUploadAsset extends FileSystemUploadDirectory {
   /**
    * Constructs a new instance of the class using the given values.
    * @param {FileSystemUploadOptions} uploadOptions URL of the options
@@ -45,3 +45,5 @@ export default class FileSystemUploadAsset extends FileSystemUploadDirectory {
     return this.size;
   }
 }
+
+module.exports = FileSystemUploadAsset;

--- a/src/filesystem-upload-directory.js
+++ b/src/filesystem-upload-directory.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import Path from 'path';
+const Path = require('path');
 
 /**
  * Represents a directory that will be created in the target AEM
@@ -18,7 +18,7 @@ import Path from 'path';
  * remote path of the folder is consistent with the configuration
  * of the upload.
  */
-export default class FileSystemUploadDirectory {
+class FileSystemUploadDirectory {
   /**
    * Constructs a new directory instance with the given values.
    * @param {FileSystemUploadOptions} uploadOptions The URL from
@@ -94,3 +94,5 @@ export default class FileSystemUploadDirectory {
     return Path.basename(this.localPath);
   }
 }
+
+module.exports = FileSystemUploadDirectory;

--- a/src/filesystem-upload-item-manager.js
+++ b/src/filesystem-upload-item-manager.js
@@ -10,16 +10,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import Path from 'path';
+const Path = require('path');
 
-import { normalizePath } from './utils';
-import FileSystemUploadDirectory from './filesystem-upload-directory';
-import FileSystemUploadAsset from './filesystem-upload-asset';
-import {
+const { normalizePath } = require('./utils');
+const FileSystemUploadDirectory = require('./filesystem-upload-directory');
+const FileSystemUploadAsset = require('./filesystem-upload-asset');
+const {
   cleanFolderName,
   cleanAssetName,
   getItemManagerParent,
-} from './filesystem-upload-utils';
+} = require('./filesystem-upload-utils');
 
 /**
  * Keeps track of FileSystemUploadDirectory and FileSystemUploadAsset
@@ -29,7 +29,7 @@ import {
  * create necessary instances for parent directories up until the
  * manager's root path.
  */
-export default class FileSystemUploadItemManager {
+class FileSystemUploadItemManager {
   /**
    * Constructs a new, empty instance of the manager that will use
    * a the given information.
@@ -131,3 +131,5 @@ export default class FileSystemUploadItemManager {
     return this.assets.has(normalizePath(localPath));
   }
 }
+
+module.exports = FileSystemUploadItemManager;

--- a/src/filesystem-upload-options.js
+++ b/src/filesystem-upload-options.js
@@ -10,16 +10,16 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import DirectBinaryUploadOptions from './direct-binary-upload-options';
-import { DefaultValues, RegularExpressions } from './constants';
-import UploadError from './upload-error';
-import ErrorCodes from './error-codes';
+const DirectBinaryUploadOptions = require('./direct-binary-upload-options');
+const { DefaultValues, RegularExpressions } = require('./constants');
+const UploadError = require('./upload-error');
+const ErrorCodes = require('./error-codes');
 
 /**
  * Options specific to a file system upload. Also supports all options defined by
  * DirectBinaryUploadOptions.
  */
-export default class FileSystemUploadOptions extends DirectBinaryUploadOptions {
+class FileSystemUploadOptions extends DirectBinaryUploadOptions {
   constructor() {
     super();
     this.replaceValue = '-';
@@ -225,3 +225,5 @@ export default class FileSystemUploadOptions extends DirectBinaryUploadOptions {
     return this.uploadFileOptions || {};
   }
 }
+
+module.exports = FileSystemUploadOptions;

--- a/src/filesystem-upload-utils.js
+++ b/src/filesystem-upload-utils.js
@@ -14,8 +14,8 @@ const Path = require('path');
 
 const { DefaultValues, RegularExpressions } = require('./constants');
 const { normalizePath } = require('./utils');
-const { default: UploadError } = require('./upload-error');
-const { default: ErrorCodes } = require('./error-codes');
+const UploadError = require('./upload-error');
+const ErrorCodes = require('./error-codes');
 
 /**
  * Retrieves the option indicating whether or not the upload is deep. Takes

--- a/src/filesystem-upload.js
+++ b/src/filesystem-upload.js
@@ -10,37 +10,37 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import Path from 'path';
-import fs from './fs-promise';
+const Path = require('path');
+const fs = require('./fs-promise');
 
-import DirectBinaryUpload from './direct-binary-upload';
-import DirectBinaryUploadProcess from './direct-binary-upload-process';
-import FileSystemUploadOptions from './filesystem-upload-options';
-import {
+const DirectBinaryUpload = require('./direct-binary-upload');
+const DirectBinaryUploadProcess = require('./direct-binary-upload-process');
+const FileSystemUploadOptions = require('./filesystem-upload-options');
+const {
   trimContentDam,
   walkDirectory,
   isTempPath,
-} from './utils';
-import {
+} = require('./utils');
+const {
   updateOptionsWithResponse,
-} from './http-utils';
-import UploadError from './upload-error';
-import ErrorCodes from './error-codes';
-import UploadResult from './upload-result';
-import HttpClient from './http/http-client';
-import HttpRequest from './http/http-request';
-import {
+} = require('./http-utils');
+const UploadError = require('./upload-error');
+const ErrorCodes = require('./error-codes');
+const UploadResult = require('./upload-result');
+const HttpClient = require('./http/http-client');
+const HttpRequest = require('./http/http-request');
+const {
   isDeepUpload,
   getMaxFileCount,
-} from './filesystem-upload-utils';
-import FileSystemUploadItemManager from './filesystem-upload-item-manager';
-import CreateDirectoryResult from './create-directory-result';
+} = require('./filesystem-upload-utils');
+const FileSystemUploadItemManager = require('./filesystem-upload-item-manager');
+const CreateDirectoryResult = require('./create-directory-result');
 
 /**
  * Uploads one or more files from the local file system to a target AEM instance using direct
  * binary access.
  */
-export default class FileSystemUpload extends DirectBinaryUpload {
+class FileSystemUpload extends DirectBinaryUpload {
   /**
    * Retrieves information from the local file system for a list of files, creates a new directory
    * in AEM, then uploads each of the local files to the new directory using direct binary access.
@@ -369,3 +369,5 @@ export default class FileSystemUpload extends DirectBinaryUpload {
     }
   }
 }
+
+module.exports = FileSystemUpload;

--- a/src/fs-promise.js
+++ b/src/fs-promise.js
@@ -10,9 +10,9 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import fs from 'fs';
-import UploadError from './upload-error';
-import ErrorCodes from './error-codes';
+const fs = require('fs');
+const UploadError = require('./upload-error');
+const ErrorCodes = require('./error-codes');
 
 const unsupportedError = () => {
   throw new UploadError('filesystem operations are not permitted in a browser', ErrorCodes.INVALID_OPTIONS);
@@ -47,7 +47,7 @@ if (fs) {
   createReadStream = fs.createReadStream;
 }
 
-export default {
+module.exports = {
   stat,
   readdir,
   createReadStream,

--- a/src/http-proxy.js
+++ b/src/http-proxy.js
@@ -10,17 +10,17 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import URL from 'url';
+const URL = require('url');
 
-import UploadError from './upload-error';
-import ErrorCodes from './error-codes';
+const UploadError = require('./upload-error');
+const ErrorCodes = require('./error-codes');
 
 const PRIVATE = Symbol('PRIVATE');
 
 /**
  * Represents information about the proxy to use when sending HTTP requests.
  */
-export default class HttpProxy {
+class HttpProxy {
   /**
    * Constructs new proxy information using the given proxy URL. By default, authentication will
    * not be used with the proxy.
@@ -124,3 +124,5 @@ export default class HttpProxy {
     return options;
   }
 }
+
+module.exports = HttpProxy;

--- a/src/http-result.js
+++ b/src/http-result.js
@@ -10,10 +10,10 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import UploadOptionsBase from './upload-options-base';
-import UploadError from './upload-error';
+const UploadOptionsBase = require('./upload-options-base');
+const UploadError = require('./upload-error');
 
-export default class HttpResult extends UploadOptionsBase {
+class HttpResult extends UploadOptionsBase {
   /**
    * Constructs a new instance of the results, which can be used to add more information.
    */
@@ -61,3 +61,5 @@ export default class HttpResult extends UploadOptionsBase {
     };
   }
 }
+
+module.exports = HttpResult;

--- a/src/http-utils.js
+++ b/src/http-utils.js
@@ -10,14 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import axios, { CancelToken } from 'axios';
-import cookie from 'cookie';
-import URL from 'url';
-import HttpProxyAgent from 'http-proxy-agent';
-import HttpsProxyAgent from 'https-proxy-agent';
+const axios = require('axios');
+const cookie = require('cookie');
+const URL = require('url');
+const HttpProxyAgent = require('http-proxy-agent');
+const HttpsProxyAgent = require('https-proxy-agent');
 
-import { exponentialRetry } from './utils';
-import UploadFile from './upload-file';
+const { exponentialRetry } = require('./utils');
+const UploadFile = require('./upload-file');
 
 /**
  * Retrieves a token that can be used to cancel an http request.
@@ -25,7 +25,7 @@ import UploadFile from './upload-file';
  * @returns {Object} Used to cancel an HTTP request.
  */
 function createCancelToken() {
-  return CancelToken.source();
+  return axios.CancelToken.source();
 }
 
 /**
@@ -197,7 +197,7 @@ function getHttpTransferOptions(options, directBinaryUploadOptions) {
   return transferOptions;
 }
 
-export {
+module.exports = {
   createCancelToken,
   timedRequest,
   isRetryableError,

--- a/src/http/http-client.js
+++ b/src/http/http-client.js
@@ -10,12 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { v4 as uuid } from 'uuid';
-import { timedRequest, createCancelToken, isRetryableError } from '../http-utils';
-import ErrorCodes from '../error-codes';
-import UploadOptionsBase from '../upload-options-base';
-import UploadError from '../upload-error';
-import HttpResponse from './http-response';
+const { v4: uuid } = require('uuid');
+const { timedRequest, createCancelToken, isRetryableError } = require('../http-utils');
+const ErrorCodes = require('../error-codes');
+const UploadOptionsBase = require('../upload-options-base');
+const UploadError = require('../upload-error');
+const HttpResponse = require('./http-response');
 
 /**
  * Invoked when there is an immediate retry error. Handles special cases and adds the
@@ -115,7 +115,7 @@ function cancelFromController(cancelEventData) {
  * client include retrying failed requests, timing request duration, and canceling
  * in-progress requests.
  */
-export default class HttpClient extends UploadOptionsBase {
+class HttpClient extends UploadOptionsBase {
   /**
    * Constructs a new instance of an HTTP request client using the given
    * information.
@@ -223,3 +223,5 @@ export default class HttpClient extends UploadOptionsBase {
     }
   }
 }
+
+module.exports = HttpClient;

--- a/src/http/http-request.js
+++ b/src/http/http-request.js
@@ -10,11 +10,11 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { Readable } from 'stream';
-import UploadBase from '../upload-base';
-import { DefaultValues } from '../constants';
-import UploadError from '../upload-error';
-import ErrorCodes from '../error-codes';
+const { Readable } = require('stream');
+const UploadBase = require('../upload-base');
+const { DefaultValues } = require('../constants');
+const UploadError = require('../upload-error');
+const ErrorCodes = require('../error-codes');
 
 /**
  * Represents a request that can be sent via HTTP using the HttpClient. Options on
@@ -255,4 +255,4 @@ HttpRequest.ResponseType = {
   BLOB: 'blob',
 };
 
-export default HttpRequest;
+module.exports = HttpRequest;

--- a/src/http/http-response.js
+++ b/src/http/http-response.js
@@ -10,13 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import UploadBase from '../upload-base';
+const UploadBase = require('../upload-base');
 
 /**
  * Represents a response received from the HttpClient after submitting a request. Provides
  * various accessors for retrieving information from the response.
  */
-export default class HttpResponse extends UploadBase {
+class HttpResponse extends UploadBase {
   /**
    * Constructs a new response, which will use raw response values from the underlying
    * module that performs HTTP communication.
@@ -79,3 +79,5 @@ export default class HttpResponse extends UploadBase {
     return this.rawResponse ? this.rawResponse.elapsedTime : 0;
   }
 }
+
+module.exports = HttpResponse;

--- a/src/upload-base.js
+++ b/src/upload-base.js
@@ -10,13 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { EventEmitter } from 'events';
+const { EventEmitter } = require('events');
 
 /**
  * Base class providing common functionality for an upload based on options
  * provided to a direct binary access-related instance.
  */
-export default class UploadBase extends EventEmitter {
+class UploadBase extends EventEmitter {
   /**
    * Initializes a new upload instance with the given options.
    *
@@ -90,7 +90,7 @@ export default class UploadBase extends EventEmitter {
    * Builds information about an upload, which will be included in upload-level
    * events sent by the uploader process.
    *
-   * @param {import('./direct-binary-upload-process').default} uploadProcess The
+   * @param {import('./direct-binary-upload-process')} uploadProcess The
    *  upload process that will be performing the work of the upload.
    * @param {number} [directoryCount=0] If specified, the number of directories
    *  that will be created by the upload process.
@@ -108,7 +108,7 @@ export default class UploadBase extends EventEmitter {
   /**
    * Sends an event that will inform consumers that items are about to be uploaded.
    *
-   * @param {import('./direct-binary-upload-process').default} uploadProcess The
+   * @param {import('./direct-binary-upload-process')} uploadProcess The
    *  upload process that will be performing the work of the upload.
    * @param {number} [directoryCount=0] If specified, the number of directories
    *  that will be created by the upload process.
@@ -120,9 +120,9 @@ export default class UploadBase extends EventEmitter {
   /**
    * Sends an event that will inform consumers that items have finished uploading.
    *
-   * @param {import('./direct-binary-upload-process').default} uploadProcess The
+   * @param {import('./direct-binary-upload-process')} uploadProcess The
    *  upload process that will be performing the work of the upload.
-   * @param {import('./upload-result').default} uploadResult Result information
+   * @param {import('./upload-result')} uploadResult Result information
    *  about the upload.
    * @param {number} [directoryCount=0] If specified, the number of directories
    *  that will be created by the upload process.
@@ -137,9 +137,9 @@ export default class UploadBase extends EventEmitter {
   /**
    * Does the work of executing an upload of one or more files to AEM.
    *
-   * @param {import('./direct-binary-upload-process').default} uploadProcess The
+   * @param {import('./direct-binary-upload-process')} uploadProcess The
    *  upload process that will be performing the work of the upload.
-   * @param {import('./upload-result').default} uploadResult Result information
+   * @param {import('./upload-result')} uploadResult Result information
    *  about the upload.
    * @returns {Promise} Resolves when the upload has finished.
    */
@@ -157,3 +157,5 @@ export default class UploadBase extends EventEmitter {
     }
   }
 }
+
+module.exports = UploadBase;

--- a/src/upload-error.js
+++ b/src/upload-error.js
@@ -10,7 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import errorCodes from './error-codes';
+const errorCodes = require('./error-codes');
 
 /**
  * Concatenates to message values together if both are provided.
@@ -33,7 +33,7 @@ function getFullMessage(overallMessage, specificMessage) {
  * primarily consists of an error code, which can be used by consumers to provide more specific
  * information about the nature of an error.
  */
-export default class UploadError extends Error {
+class UploadError extends Error {
   /**
    * Constructs a new UploadError instance out of a given error message. The method will attempt
    * to create the most specific type of error it can based on what it receives.
@@ -200,3 +200,5 @@ export default class UploadError extends Error {
     return JSON.stringify(this);
   }
 }
+
+module.exports = UploadError;

--- a/src/upload-file.js
+++ b/src/upload-file.js
@@ -10,12 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import fs from 'fs';
-import Path from 'path';
+const fs = require('fs');
+const Path = require('path');
 
-import UploadOptionsBase from './upload-options-base';
-import UploadError from './upload-error';
-import ErrorCodes from './error-codes';
+const UploadOptionsBase = require('./upload-options-base');
+const UploadError = require('./upload-error');
+const ErrorCodes = require('./error-codes');
 
 /**
  * Analyzes the given file options and determines if there is sufficient information
@@ -38,7 +38,7 @@ function ensureRequiredOptions(options) {
  * Represents a file to upload, as provided in upload options. Includes information like the file's
  * name and size. Also provide capabilities for reading chunks of the file.
  */
-export default class UploadFile extends UploadOptionsBase {
+class UploadFile extends UploadOptionsBase {
   /**
    * Constructs a new instance based on the given information.
    *
@@ -214,3 +214,5 @@ export default class UploadFile extends UploadOptionsBase {
     return json;
   }
 }
+
+module.exports = UploadFile;

--- a/src/upload-options-base.js
+++ b/src/upload-options-base.js
@@ -10,13 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import UploadBase from './upload-base';
+const UploadBase = require('./upload-base');
 
 /**
  * Common base class for all classes that work with a DirectBinaryUploadOptions
  * instance.
  */
-export default class UploadOptionsBase extends UploadBase {
+class UploadOptionsBase extends UploadBase {
   /**
    * Constructs a new instance using the provided information.
    *
@@ -38,3 +38,5 @@ export default class UploadOptionsBase extends UploadBase {
     return this.uploadOptions;
   }
 }
+
+module.exports = UploadOptionsBase;

--- a/src/upload-result.js
+++ b/src/upload-result.js
@@ -10,14 +10,14 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import HttpResult from './http-result';
-import UploadError from './upload-error';
+const HttpResult = require('./http-result');
+const UploadError = require('./upload-error');
 
 /**
  * Represents results for the upload process as a whole, which might include multiple files. Results
  * include information such as total upload time, total file size, total number of files, etc.
  */
-export default class UploadResult extends HttpResult {
+class UploadResult extends HttpResult {
   /**
    * Constructs a new instance of the results, which can be used to add more information.
    *
@@ -55,7 +55,7 @@ export default class UploadResult extends HttpResult {
    * Adds a new create directory to the overall result. Will be used to calculate various overall
    * metrics.
    *
-   * @param {import('./create-directory-result').default} createDirectoryResult Result whose
+   * @param {import('./create-directory-result')} createDirectoryResult Result whose
    *   metrics will be included in the overall result.
    */
   addCreateDirectoryResult(createDirectoryResult) {
@@ -65,7 +65,7 @@ export default class UploadResult extends HttpResult {
   /**
    * Retrieves all results for directories that were created as part of the upload.
    *
-   * @returns {Array<import('./create-directory-result').default>} Directory results.
+   * @returns {Array<import('./create-directory-result')>} Directory results.
    */
   getCreateDirectoryResults() {
     return this.createDirectoryResults;
@@ -86,7 +86,7 @@ export default class UploadResult extends HttpResult {
   /**
    * Sets information the individual file upload results that will be included in the final
    * output.
-   * @param {import('./file-upload-results').default} fileUploadResults File upload information.
+   * @param {import('./file-upload-results')} fileUploadResults File upload information.
    */
   setFileUploadResults(fileUploadResults) {
     this.fileUploadResults = fileUploadResults;
@@ -206,3 +206,5 @@ export default class UploadResult extends HttpResult {
     };
   }
 }
+
+module.exports = UploadResult;

--- a/test/create-directory-result.test.js
+++ b/test/create-directory-result.test.js
@@ -17,11 +17,11 @@ const should = require('should');
 const {
   getTestOptions,
 } = require('./testutils');
-const FileSystemUploadOptions = require('../src/filesystem-upload-options').default;
-const CreateDirectoryResult = require('../src/create-directory-result').default;
-const HttpResponse = require('../src/http/http-response').default;
-const UploadError = require('../src/upload-error').default;
-const ErrorCodes = require('../src/error-codes').default;
+const FileSystemUploadOptions = require('../src/filesystem-upload-options');
+const CreateDirectoryResult = require('../src/create-directory-result');
+const HttpResponse = require('../src/http/http-response');
+const UploadError = require('../src/upload-error');
+const ErrorCodes = require('../src/error-codes');
 
 describe('Create Directy Result Tests', () => {
   it('test result with response', () => {

--- a/test/direct-binary-upload-options.test.js
+++ b/test/direct-binary-upload-options.test.js
@@ -15,9 +15,7 @@ governing permissions and limitations under the License.
 const should = require('should');
 const cookie = require('cookie');
 
-const { importFile } = require('./testutils');
-
-const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
+const DirectBinaryUploadOptions = require('../src/direct-binary-upload-options');
 
 describe('DirectBinaryUploadOptionsTest', () => {
   it('test url slashes', () => {

--- a/test/direct-binary-upload-process.test.js
+++ b/test/direct-binary-upload-process.test.js
@@ -15,15 +15,12 @@ governing permissions and limitations under the License.
 const should = require('should');
 const { Readable } = require('stream');
 
-const { importFile, getTestOptions } = require('./testutils');
+const { getTestOptions } = require('./testutils');
 const MockRequest = require('./mock-request');
 const MockBlob = require('./mock-blob');
-
-const UploadResult = importFile('upload-result');
-
-const DirectBinaryUploadProcess = importFile('direct-binary-upload-process');
-
-const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
+const UploadResult = require('../src/upload-result');
+const DirectBinaryUploadProcess = require('../src/direct-binary-upload-process');
+const DirectBinaryUploadOptions = require('../src/direct-binary-upload-options');
 
 describe('DirectBinaryUploadProcessTest', () => {
   beforeEach(() => {

--- a/test/direct-binary-upload.test.js
+++ b/test/direct-binary-upload.test.js
@@ -14,12 +14,12 @@ governing permissions and limitations under the License.
 
 const should = require('should');
 
-const { importFile, getTestOptions, verifyResult } = require('./testutils');
+const { getTestOptions, verifyResult } = require('./testutils');
 const MockRequest = require('./mock-request');
 const MockBlob = require('./mock-blob');
 
-const DirectBinaryUpload = importFile('direct-binary-upload');
-const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
+const DirectBinaryUpload = require('../src/direct-binary-upload');
+const DirectBinaryUploadOptions = require('../src/direct-binary-upload-options');
 
 let blob1; let blob2; let
   events;

--- a/test/exports.test.js
+++ b/test/exports.test.js
@@ -12,17 +12,16 @@ governing permissions and limitations under the License.
 
 /* eslint-env mocha */
 
-import should from 'should';
-import Exports, { DirectBinaryUploadOptions } from '../src/exports';
+const should = require('should');
+const Exports = require('../src/exports');
+const { DirectBinaryUploadOptions } = require('../src/exports');
 
 describe('Exports Tests', () => {
   it('test exports smoke test', () => {
     should(Exports).be.ok();
-    // eslint-disable-next-line import/no-named-as-default-member
     should(Exports.DirectBinaryUploadOptions).be.ok();
     should(DirectBinaryUploadOptions).be.ok();
 
-    // eslint-disable-next-line import/no-named-as-default-member
     should(new Exports.DirectBinaryUploadOptions()).be.ok();
     should(new DirectBinaryUploadOptions()).be.ok();
   });

--- a/test/filesystem-upload-directory.test.js
+++ b/test/filesystem-upload-directory.test.js
@@ -14,10 +14,8 @@ governing permissions and limitations under the License.
 
 const should = require('should');
 
-const { importFile } = require('./testutils');
-
-const FileSystemUploadDirectory = importFile('filesystem-upload-directory');
-const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
+const FileSystemUploadDirectory = require('../src/filesystem-upload-directory');
+const DirectBinaryUploadOptions = require('../src/direct-binary-upload-options');
 
 describe('FileSystemUploadDirectory Tests', () => {
   it('test get remote path', () => {

--- a/test/filesystem-upload-item-manager.test.js
+++ b/test/filesystem-upload-item-manager.test.js
@@ -14,10 +14,8 @@ governing permissions and limitations under the License.
 
 const should = require('should');
 
-const { importFile } = require('./testutils');
-
-const FileSystemUploadOptions = importFile('filesystem-upload-options');
-const FileSystemUploadItemManager = importFile('filesystem-upload-item-manager');
+const FileSystemUploadOptions = require('../src/filesystem-upload-options');
+const FileSystemUploadItemManager = require('../src/filesystem-upload-item-manager');
 
 describe('FileSystemUploadItemManager Tests', () => {
   let options;

--- a/test/filesystem-upload-options.test.js
+++ b/test/filesystem-upload-options.test.js
@@ -14,10 +14,8 @@ governing permissions and limitations under the License.
 
 const should = require('should');
 
-const { importFile } = require('./testutils');
-
-const FileSystemUploadOptions = importFile('filesystem-upload-options');
-const HttpProxy = importFile('http-proxy');
+const FileSystemUploadOptions = require('../src/filesystem-upload-options');
+const HttpProxy = require('../src/http-proxy');
 
 describe('FileSystemUploadOptions Tests', () => {
   let options;

--- a/test/filesystem-upload-utils.test.js
+++ b/test/filesystem-upload-utils.test.js
@@ -14,10 +14,8 @@ governing permissions and limitations under the License.
 
 const should = require('should');
 
-const { importFile } = require('./testutils');
-
-const { cleanFolderName, cleanAssetName } = importFile('filesystem-upload-utils');
-const FileSystemUploadOptions = importFile('filesystem-upload-options');
+const { cleanFolderName, cleanAssetName } = require('../src/filesystem-upload-utils');
+const FileSystemUploadOptions = require('../src/filesystem-upload-options');
 
 describe('FileSystemUploadUtils Tests', () => {
   let options;

--- a/test/filesystem-upload.test.js
+++ b/test/filesystem-upload.test.js
@@ -16,7 +16,6 @@ const should = require('should');
 const MockFs = require('mock-fs');
 
 const {
-  importFile,
   getTestOptions,
   monitorEvents,
   getEvent,
@@ -25,10 +24,10 @@ const {
 } = require('./testutils');
 const MockRequest = require('./mock-request');
 
-const HttpClient = importFile('http/http-client');
-const FileSystemUploadDirectory = importFile('filesystem-upload-directory');
-const HttpProxy = importFile('http-proxy');
-const UploadResult = importFile('upload-result');
+const HttpClient = require('../src/http/http-client');
+const FileSystemUploadDirectory = require('../src/filesystem-upload-directory');
+const HttpProxy = require('../src/http-proxy');
+const UploadResult = require('../src/upload-result');
 
 function MockDirectBinaryUpload() {
 
@@ -38,9 +37,9 @@ MockDirectBinaryUpload.prototype.uploadFiles = (uploadOptions) => new Promise((r
   resolve(uploadOptions);
 });
 
-const FileSystemUploadOptions = importFile('filesystem-upload-options');
+const FileSystemUploadOptions = require('../src/filesystem-upload-options');
 
-const FileSystemUpload = importFile('filesystem-upload');
+const FileSystemUpload = require('../src/filesystem-upload');
 
 const SUBDIR = 'sub吏dir';
 const SUBDIR_ENCODED = encodeURI(SUBDIR);

--- a/test/http-proxy.test.js
+++ b/test/http-proxy.test.js
@@ -14,11 +14,7 @@ governing permissions and limitations under the License.
 
 const should = require('should');
 
-const {
-  importFile,
-} = require('./testutils');
-
-const HttpProxy = importFile('http-proxy');
+const HttpProxy = require('../src/http-proxy');
 
 describe('HTTP proxy tests', () => {
   it('test accessors', () => {

--- a/test/http-utils.test.js
+++ b/test/http-utils.test.js
@@ -15,11 +15,11 @@ governing permissions and limitations under the License.
 const should = require('should');
 const cookie = require('cookie');
 
-const { importFile, getTestOptions } = require('./testutils');
+const { getTestOptions } = require('./testutils');
 const MockRequest = require('./mock-request');
-const { default: HttpResponse } = require('../src/http/http-response');
+const HttpResponse = require('../src/http/http-response');
 
-const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
+const DirectBinaryUploadOptions = require('../src/direct-binary-upload-options');
 
 const {
   timedRequest,
@@ -27,8 +27,8 @@ const {
   isRetryableError,
   getProxyAgentOptions,
   getHttpTransferOptions,
-} = importFile('http-utils');
-const HttpProxy = importFile('http-proxy');
+} = require('../src/http-utils');
+const HttpProxy = require('../src/http-proxy');
 
 describe('HttpUtilsTest', () => {
   beforeEach(() => {

--- a/test/http/http-client.test.js
+++ b/test/http/http-client.test.js
@@ -16,13 +16,13 @@ const should = require('should');
 const { EventEmitter } = require('events');
 const Sinon = require('sinon');
 
-const { importFile, getTestOptions } = require('../testutils');
+const { getTestOptions } = require('../testutils');
 const MockRequest = require('../mock-request');
 
-const HttpClient = importFile('http/http-client');
-const HttpRequest = importFile('http/http-request');
-const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
-const HttpResult = importFile('http-result');
+const HttpClient = require('../../src/http/http-client');
+const HttpRequest = require('../../src/http/http-request');
+const DirectBinaryUploadOptions = require('../../src/direct-binary-upload-options');
+const HttpResult = require('../../src/http-result');
 
 const HOST = 'http://adobe-aem-upload-unit-test';
 

--- a/test/http/http-request.test.js
+++ b/test/http/http-request.test.js
@@ -18,11 +18,11 @@ const fs = require('fs');
 const MockFs = require('mock-fs');
 const Sinon = require('sinon');
 
-const { importFile, getTestOptions } = require('../testutils');
+const { getTestOptions } = require('../testutils');
 
-const HttpRequest = importFile('http/http-request');
-const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
-const HttpProxy = importFile('http-proxy');
+const HttpRequest = require('../../src/http/http-request');
+const DirectBinaryUploadOptions = require('../../src/direct-binary-upload-options');
+const HttpProxy = require('../../src/http-proxy');
 
 const HOST = 'http://adobe-aem-upload-unit-test';
 

--- a/test/http/http-response.test.js
+++ b/test/http/http-response.test.js
@@ -14,9 +14,7 @@ governing permissions and limitations under the License.
 
 const should = require('should');
 
-const { importFile } = require('../testutils');
-
-const HttpResponse = importFile('http/http-response');
+const HttpResponse = require('../../src/http/http-response');
 
 describe('HTTP Response Tests', () => {
   it('test accessors', () => {

--- a/test/mock-request.js
+++ b/test/mock-request.js
@@ -14,7 +14,7 @@ const querystring = require('querystring');
 const URL = require('url');
 const axios = require('axios');
 const MockAdapter = require('axios-mock-adapter');
-const HttpTransfer = require('@adobe/httptransfer/es2015');
+const HttpTransfer = require('@adobe/httptransfer');
 const mime = require('mime');
 const should = require('should');
 

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -10,45 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-require('core-js');
-require('regenerator-runtime');
-
-const proxyquire = require('proxyquire').noCallThru();
 const should = require('should');
-
-function getImportPath(file) {
-  return `../src/${file}`;
-}
-
-module.exports.getImportPath = getImportPath;
-
-/**
- * Requires a file from the project's src directory, applying a given set of
- * Mock objects to it.
- *
- * @param {string} file The path to the file to import, from the src/ directory. For
- *  example, "http-utils".
- * @param {object} fileMocks A lookup containing objects that should be mocked. The
- *  key should be the name of the module to Mock, and the value is the object to
- *  return when the mocked module is required. If the module is installed, the name
- *  can simply be the name of the module (such as "fs"). If the module is in the
- *  project, the name should be the relative path to the file from the src/ directory
- *  (such as "./upload-file").
- */
-module.exports.importFile = (file, fileMocks) => {
-  const requirePath = getImportPath(file);
-  let required;
-  if (fileMocks) {
-    required = proxyquire(requirePath, fileMocks);
-  } else {
-    // eslint-disable-next-line import/no-dynamic-require, global-require
-    required = require(requirePath);
-  }
-  if (required && required.default) {
-    return required.default;
-  }
-  return required;
-};
 
 function getConsoleLogger() {
   return {

--- a/test/upload-file.test.js
+++ b/test/upload-file.test.js
@@ -14,10 +14,10 @@ governing permissions and limitations under the License.
 
 const should = require('should');
 
-const { importFile, getTestOptions } = require('./testutils');
+const { getTestOptions } = require('./testutils');
 
-const DirectBinaryUploadOptions = importFile('direct-binary-upload-options');
-const UploadFile = importFile('upload-file');
+const DirectBinaryUploadOptions = require('../src/direct-binary-upload-options');
+const UploadFile = require('../src/upload-file');
 
 describe('UploadFile Tests', () => {
   function ensureFailure(options, uploadOptions, fileOptions) {

--- a/test/upload-result.test.js
+++ b/test/upload-result.test.js
@@ -15,9 +15,7 @@ governing permissions and limitations under the License.
 const should = require('should');
 const Sinon = require('sinon');
 
-const { importFile } = require('./testutils');
-
-const UploadResult = importFile('upload-result');
+const UploadResult = require('../src/upload-result');
 
 describe('UploadResult Tests', () => {
   // eslint-disable-next-line func-names


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This library was originally created as a blend between module syntax and non-module syntax. As such, the code wasn't always consistent, and the module's export was all transpiled code (i.e. the unaltered code was not used).

This PR brings all code inline so that the library is _not_ a module, and changes the exports so that the unmodified code is used as its primary export. The transpiled code is still included, and is available in the `dist` directory (which is also the target for the `browser` element in `package.json`).

The original library code can now be used as a dependency in both modules and non-modules.

## Related Issue

N/A

## Motivation and Context

Simplify debugging and troubleshooting by providing raw code as the export. Increase consistency and ensure that the library is _not_ a module.

## How Has This Been Tested?

Unit tests and e2e tests pass locally.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
