### PR TITLE
fix node.js version on which semantic-release step runs

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -32,9 +32,6 @@ jobs:
       run: npm install
     - name: Build
       run: npm run build
-    - name: Lint
-      if: ${{ matrix.node-version == '10.16' }}
-      run: npm run lint
     - name: Run unit tests
       run: npm test
 
@@ -53,10 +50,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
-      - name: Use Node.js 12.19
+      - name: Use Node.js 18.16
         uses: actions/setup-node@v1
         with:
-          node-version: '12.19'
+          node-version: '18.16'
       - run: npm install
       - run: npm run build
       - run: npm run semantic-release


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The semantic-release portion of the CI began failing after upgrading to the newest version of semantic-release. Root cause was that the release step was running on version 12 of node. Updated the step to run on version 18 instead.

## Related Issue

N/A

## Motivation and Context

Keeping dependencies updated.

## How Has This Been Tested?

N/A

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
