### PR TITLE
update to latest node-httptransfer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/cloud-service-client": "^1.1.0",
-        "@adobe/httptransfer": "^3.3.0",
+        "@adobe/httptransfer": "^3.3.1",
         "async": "^3.2.0",
         "async-lock": "^1.2.8",
         "filesize": "^4.2.1",
@@ -3058,9 +3058,9 @@
       "optional": true
     },
     "node_modules/@adobe/httptransfer": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@adobe/httptransfer/-/httptransfer-3.3.0.tgz",
-      "integrity": "sha512-F9/u26v47dg0qs0I5FhF1Ycto8CUhaI+WxWM2BSwdgxpl8TqYTQPAsfs2ZZJRq2f0IfMKmBX8BesxGfnr6DT3Q==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/httptransfer/-/httptransfer-3.3.1.tgz",
+      "integrity": "sha512-tbKgk7/vRaIqihZeszCC+b30rG13d5fK4/eoL65zMJ7issNZjFGokk67Rfphr97Zou9ue8NgySc3bHzsi2Im1g==",
       "dependencies": {
         "@babel/runtime": "^7.16.7",
         "content-disposition": "^0.5.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "bugs": "https://github.com/adobe/aem-upload",
   "dependencies": {
     "@adobe/cloud-service-client": "^1.1.0",
-    "@adobe/httptransfer": "^3.3.0",
+    "@adobe/httptransfer": "^3.3.1",
     "async": "^3.2.0",
     "async-lock": "^1.2.8",
     "filesize": "^4.2.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

See details on [node-httptransfer](https://github.com/adobe/node-httptransfer/issues/145). In summary, uploading to non-cloud AEM instances fails in some conditions. This PR fixes that issue.

## Related Issue

See link above.

## Motivation and Context

See link above.

## How Has This Been Tested?

Unit tests and e2e tests pass. Updating library locally and running a test passes.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
