### PR TITLE
improve support for handling eventual consistency when uploading.

### DIFF
--- a/src/http-utils.js
+++ b/src/http-utils.js
@@ -61,12 +61,26 @@ function getHttpTransferOptions(options, directBinaryUploadOptions) {
     delete requestOptions.headers;
   }
 
+  const retryOptions = {
+    retryInitialDelay: directBinaryUploadOptions.getHttpRetryDelay(),
+    retryMaxCount: directBinaryUploadOptions.getHttpRetryCount(),
+    retryAllErrors: false,
+  };
+  if (requestOptions.cloudClient) {
+    retryOptions.retryAllErrors = requestOptions.cloudClient.eventuallyConsistentCreate || false;
+    delete requestOptions.cloudClient;
+  }
+
   const transferOptions = {
     uploadFiles: convertedFiles,
     concurrent: directBinaryUploadOptions.isConcurrent(),
     maxConcurrent: directBinaryUploadOptions.getMaxConcurrent(),
+    timeout: directBinaryUploadOptions.getHttpRequestTimeout(),
     headers,
-    requestOptions,
+    requestOptions: {
+      retryOptions,
+      ...requestOptions,
+    },
   };
 
   return transferOptions;

--- a/test/http-utils.test.js
+++ b/test/http-utils.test.js
@@ -28,7 +28,14 @@ describe('HttpUtilsTest', () => {
       .withUrl('http://localhost/content/dam');
     let httpTransfer = getHttpTransferOptions(getTestOptions(), uploadOptions);
     should(httpTransfer).deepEqual({
-      requestOptions: {},
+      requestOptions: {
+        retryOptions: {
+          retryAllErrors: false,
+          retryInitialDelay: 5000,
+          retryMaxCount: 3,
+        },
+      },
+      timeout: 60000,
       concurrent: true,
       maxConcurrent: 5,
       uploadFiles: [],
@@ -41,7 +48,13 @@ describe('HttpUtilsTest', () => {
           hello: 'world!',
         },
         method: 'DELETE',
+        cloudClient: {
+          eventuallyConsistentCreate: true,
+        },
       })
+      .withHttpRequestTimeout(30000)
+      .withHttpRetryCount(2)
+      .withHttpRetryDelay(500)
       .withUploadFiles([{
         fileSize: 1024,
         fileName: 'file.jpg',
@@ -67,9 +80,15 @@ describe('HttpUtilsTest', () => {
       },
       requestOptions: {
         method: 'DELETE',
+        retryOptions: {
+          retryAllErrors: true,
+          retryInitialDelay: 500,
+          retryMaxCount: 2,
+        },
       },
       concurrent: false,
       maxConcurrent: 1,
+      timeout: 30000,
       uploadFiles: [{
         createVersion: true,
         filePath: '/my/test/file.jpg',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The process of creating directories already handles eventual consistency with the `cloud-service-client` library. However, requests to initiate and complete uploads are performed by `node-httptransfer`, which has its own library for overcoming eventual consistency. This PR translates the `cloud-service-client` option for eventual consistency into the equivalent `node-httptransfer` option.

## Related Issue

#117 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

As described in the associated ticket, this will help avoid failures in cases where directories are created then uploaded to in very fast succession.

## How Has This Been Tested?

New unit test added, existing unit tests pass, existing e2e tests pass.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
