### PR TITLE
Fix basic authentication example

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,11 +316,12 @@ const {
 } = require('@adobe/aem-upload');
 
 // configure options to use basic authentication
+const credentials = Buffer.from('admin:admin').toString('base64')
 const options = new FileSystemUploadOptions()
     .withUrl('http://localhost:4502/content/dam/target-folder')
     .withHttpOptions({
         headers: {
-            Authorization: Buffer.from('admin:admin').toString('base64')
+            Authorization: `Basic ${credentials}`
         }
     });
 


### PR DESCRIPTION
Authorization header value is missing Basic scheme

## Description

PR add Basic scheme to the Authorization header.

## Related Issue

https://github.com/adobe/aem-upload/issues/121

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
